### PR TITLE
require rails_helper upfront instead of in each spec file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---require spec_helper
+--require rails_helper

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Carrier' do
   fixtures :locations
   let(:location) { locations(:location) }

--- a/spec/features/category_spec.rb
+++ b/spec/features/category_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.feature "category" do
   fixtures :categories
   let!(:category) { categories(:category) }

--- a/spec/features/location_spec.rb
+++ b/spec/features/location_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.feature 'create a location', type: :feature do
   fixtures :users
   let(:user) { users(:user) }

--- a/spec/features/membership_type_spec.rb
+++ b/spec/features/membership_type_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'MembershipType', type: :feature do
   fixtures :users
   let(:user) { users(:user) }

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe 'Organization' do
   fixtures :users
   let(:user) { users(:user) }

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.feature "user registration" do
   scenario "should allow user to create a user account" do
     visit "/"

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Carrier do
   fixtures :locations
   let(:location) { locations(:location) }

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Category, type: :model do
   fixtures :categories
   let!(:category) { categories(:category) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Organization, :type => :model do
   subject { 
     described_class.new(name: 'name of organization', description: 'test description') 


### PR DESCRIPTION
Lets us write fewer lines and makes writing new specs easier.