### PR TITLE
Add carrier category name to category view

### DIFF
--- a/app/views/carriers/show.html.erb
+++ b/app/views/carriers/show.html.erb
@@ -10,6 +10,7 @@
   <li>Model: <%= @carrier.model %></li>
   <li>Color: <%= @carrier.color %></li>
   <li>Size: <%= @carrier.size %></li>
+  <li>Category: <%= @carrier.category.name %></li>
   <li>Location: <%= @carrier.location.name %></li>
   <li>Default Loan Length: <%= @carrier.default_loan_length_days %> days</li>
 </ul>


### PR DESCRIPTION
### Description
When viewing a carrier, we should display the category name. Added carrier.category.name to the carrier view. 

### Type of change

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

Manually spot-checked 10 different carriers to ensure the category populated correctly.

### Screenshots

![image](https://user-images.githubusercontent.com/47750744/62008004-7adfc300-b122-11e9-9f0e-8df8f18720a1.png)
