### PR TITLE
Carts should track which volunteer processed them for the member

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,6 +1,9 @@
 class Cart < ApplicationRecord
-  belongs_to :user
-  validates :user, presence: true
+  belongs_to :member, class_name: "User"
+  validates :member, presence: true
+
+  belongs_to :volunteer, class_name: "User"
+  validates :volunteer, presence: true
 
   has_many :loans
 

--- a/db/migrate/20190728154543_add_volunteer_to_cart.rb
+++ b/db/migrate/20190728154543_add_volunteer_to_cart.rb
@@ -1,0 +1,8 @@
+class AddVolunteerToCart < ActiveRecord::Migration[5.2]
+  def change
+    change_table :carts do |t|
+      t.rename :user_id, :member_id
+      t.integer :volunteer_id, nullable: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_27_181929) do
+ActiveRecord::Schema.define(version: 2019_07_28_154543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,9 +58,10 @@ ActiveRecord::Schema.define(version: 2019_07_27_181929) do
   end
 
   create_table "carts", force: :cascade do |t|
-    t.integer "user_id"
+    t.integer "member_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "volunteer_id"
   end
 
   create_table "categories", force: :cascade do |t|

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -7,3 +7,14 @@ user:
   state: 'VA'
   postal_code: '22032'
   phone_number: '18888888888'
+
+volunteer:
+  email: 'volunteer@test.com'
+  encrypted_password: 'password'
+  full_name: 'volunteer'
+  street_address: '123 main street'
+  city: 'fairfax'
+  state: 'VA'
+  postal_code: '22032'
+  phone_number: '18888888888'
+

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe Carrier do
     context "with parameters" do
       fixtures(:users)
 
-      let(:user) { User.first }
-      let(:cart) { Cart.new(user: user) }
+      let(:member)    { users(:user) }
+      let(:volunteer) { users(:volunteer) }
+      let(:cart)      { Cart.new(member: member, volunteer: volunteer) }
 
       subject { carrier.build_loan(cart: cart) }
 

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe Cart do
   fixtures(:users)
 
-  let(:user) { User.first }
+  let(:member)    { users(:user) }
+  let(:volunteer) { users(:volunteer) }
 
   describe '#valid?' do
-    context "with a user" do
-      subject { described_class.new(user: user) }
+    context "with a member and a volunteer" do
+      subject { described_class.new(member: member, volunteer: volunteer) }
 
       it 'returns true' do
         expect(subject).to be_valid
@@ -16,10 +17,10 @@ RSpec.describe Cart do
   describe '#line_items' do
     fixtures(:carriers)
 
-    let(:carrier)  { Carrier.first }
+    let(:carrier)  { carriers(:carrier) }
     let(:due_date) { Date.today + 1.days }
 
-    subject { Cart.create!(user: user) }
+    subject { described_class.create!(member: member, volunteer: volunteer) }
 
     context "with a single loan" do
       let(:loan) { subject.loans.create!(carrier: carrier, due_date: due_date) }

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe Loan do
-  fixtures(:carriers)
-  fixtures(:users)
+  fixtures(:carriers, :users)
 
-  let(:user)    { User.first }
-  let(:cart)    { Cart.new(user: user) }
-  let(:carrier) { Carrier.first }
+  let(:member)    { users(:user) }
+  let(:volunteer) { users(:volunteer) }
+
+  let(:cart)    { Cart.new(member: member, volunteer: volunteer) }
+  let(:carrier) { carriers(:carrier) }
 
   describe '#valid?' do
     context "with a cart, a carrier, and a due date" do


### PR DESCRIPTION
Forgot this on the initial carts/loans PR, but we do need to record this information.