### PR TITLE
Users signing agreements

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -7,6 +7,7 @@ class AgreementsController < ApplicationController
   end
 
   def show
+    @signed_agreement = SignedAgreement.find_by(agreement_id: @agreement.id, user_id: current_user.id)
   end
 
   def new

--- a/app/controllers/signed_agreements_controller.rb
+++ b/app/controllers/signed_agreements_controller.rb
@@ -1,0 +1,33 @@
+class SignedAgreementsController < ApplicationController
+  before_action :set_agreement, only: [:new, :show]
+
+  def show
+    @signed_agreement = SignedAgreement.new
+  end
+
+  def create
+    @signed_agreement = SignedAgreement.new(signed_agreement_params)
+    
+    respond_to do |format|
+      if @signed_agreement.save
+        format.html { redirect_to agreements_path, notice: 'Agreement was successfully signed.' }
+      else
+        format.html { redirect_to signed_agreement_path(@signed_agreement.agreement_id), notice: @signed_agreement.errors.full_messages }
+      end
+    end
+  end
+
+  private
+
+  def set_agreement
+    @agreement = Agreement.find(params[:id])
+  end
+
+  def signed_agreement_params
+    params.require(:signed_agreement).permit(
+      :signature,
+      :user_id,
+      :agreement_id
+    )
+  end
+end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -1,3 +1,7 @@
 class Agreement < ApplicationRecord
   validates_presence_of :title, :content
+
+  def signed?(user_id)
+    SignedAgreement.where(agreement_id: id, user_id: user_id).present?
+  end
 end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -1,7 +1,9 @@
 class Agreement < ApplicationRecord
+  has_many :signed_agreements
+
   validates_presence_of :title, :content
 
-  def signed?(user_id)
-    SignedAgreement.where(agreement_id: id, user_id: user_id).present?
+  def signed_by?(user)
+    signed_agreements.where(user: user).present?
   end
 end

--- a/app/models/signed_agreement.rb
+++ b/app/models/signed_agreement.rb
@@ -1,0 +1,6 @@
+class SignedAgreement < ApplicationRecord
+  belongs_to :user
+  belongs_to :agreement
+
+  validates :signature, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :full_name, :street_address, :city,
             :state, :postal_code, :phone_number, presence: true
+
+  has_many :signed_agreements
 end

--- a/app/views/agreements/index.html.erb
+++ b/app/views/agreements/index.html.erb
@@ -15,7 +15,7 @@
   <tbody>
     <% @agreements.each do |agreement| %>
       <tr>
-        <td><%= check_box_tag 'signed', '', agreement.signed?(current_user.id), disabled: true %></td>
+        <td><%= check_box_tag 'signed', '', agreement.signed_by?(current_user), disabled: true %></td>
         <td><%= agreement.title %></td>
         
         <td><%= link_to 'Show', agreement %></td>

--- a/app/views/agreements/index.html.erb
+++ b/app/views/agreements/index.html.erb
@@ -5,6 +5,7 @@
 <table>
   <thead>
     <tr>
+      <th>Signed</th>
       <th>Title</th>
       <th>Content</th>
       <th colspan="3"></th>
@@ -14,6 +15,7 @@
   <tbody>
     <% @agreements.each do |agreement| %>
       <tr>
+        <td><%= check_box_tag 'signed', '', agreement.signed?(current_user.id), disabled: true %></td>
         <td><%= agreement.title %></td>
         
         <td><%= link_to 'Show', agreement %></td>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -1,7 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <% if @signed_agreement %>
-  <p>Agreement signed at: <%= @signed_agreement.created_at %></p>
+  <p>Agreement signed by: <%= @signed_agreement.signature %> at: <%= @signed_agreement.created_at %></p>
 <% end %>
 
 <p>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -1,5 +1,9 @@
 <p id="notice"><%= notice %></p>
 
+<% if @signed_agreement %>
+  <p>Agreement signed at: <%= @signed_agreement.created_at %></p>
+<% end %>
+
 <p>
   <strong>Title:</strong>
   <%= @agreement.title %>
@@ -10,5 +14,6 @@
   <%= @agreement.content %>
 </p>
 
+<%= link_to 'Sign', signed_agreement_path(@agreement) %> |
 <%= link_to 'Edit', edit_agreement_path(@agreement) %> |
 <%= link_to 'Back', agreements_path %>

--- a/app/views/signed_agreements/show.html.erb
+++ b/app/views/signed_agreements/show.html.erb
@@ -1,0 +1,23 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @agreement.title %>
+</p>
+
+<p>
+  <strong>Content:</strong>
+  <%= @agreement.content %>
+</p>
+
+<%= form_for @signed_agreement, url: signed_agreements_path, method: 'post' do |form| %>
+  <%= form.hidden_field :user_id %>
+  <%= hidden_field_tag 'signed_agreement[user_id]', current_user.id %>
+
+  <%= form.hidden_field :agreement_id %>
+  <%= hidden_field_tag 'signed_agreement[agreement_id]', @agreement.id %>
+  
+  <%= form.text_field :signature %>
+
+  <%= form.submit 'I Agree' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :signed_agreements, only: [:show, :create]
   resources :agreements
   resources :locations
   resources :membership_types

--- a/db/migrate/20190727202234_create_signed_agreements.rb
+++ b/db/migrate/20190727202234_create_signed_agreements.rb
@@ -1,0 +1,10 @@
+class CreateSignedAgreements < ActiveRecord::Migration[5.2]
+  def change
+    create_table :signed_agreements do |t|
+      t.belongs_to :user
+      t.belongs_to :agreement
+      t.string :signature
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_27_160127) do
+ActiveRecord::Schema.define(version: 2019_07_27_202234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,16 @@ ActiveRecord::Schema.define(version: 2019_07_27_160127) do
     t.datetime "updated_at", null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource_type_and_resource_id"
+  end
+
+  create_table "signed_agreements", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "agreement_id"
+    t.string "signature"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["agreement_id"], name: "index_signed_agreements_on_agreement_id"
+    t.index ["user_id"], name: "index_signed_agreements_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/features/agreement_spec.rb
+++ b/spec/features/agreement_spec.rb
@@ -1,27 +1,23 @@
-require 'rails_helper'
-
 RSpec.feature 'create an agreement', type: :feature do
-  fixtures :users
+  fixtures :users, :agreements
   let(:user) { users(:user) }
+  let(:agreement) { agreements(:agreement) }
 
   before :each do
     visit "/"
     sign_in user
-
-    @agreement = Agreement.new(title: 'Rules', content:'Content')
-    @agreement.save!
   end
 
   scenario 'SHOW' do
     visit agreements_path
-    click_link 'Show'
+    click_on 'Show'
 
-    expect(page).to have_content('Rules')
+    expect(page).to have_content('Test Agreement')
     expect(page).to have_content('Content')
   end
 
   scenario 'EDIT when name is NOT given' do
-    visit edit_agreement_path(@agreement.id)
+    visit edit_agreement_path(agreement.id)
 
     fill_in 'Title', with: nil
     click_on 'Update Agreement'
@@ -30,7 +26,7 @@ RSpec.feature 'create an agreement', type: :feature do
   end
 
   scenario 'EDIT when all expected information is given' do
-    visit edit_agreement_path(@agreement.id)
+    visit edit_agreement_path(agreement.id)
 
     fill_in 'Title', with: 'Fake agreement'
     fill_in 'Content', with: 'Content of Fake agreement'

--- a/spec/features/signed_agreement_spec.rb
+++ b/spec/features/signed_agreement_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe SignedAgreement do
+  fixtures :users
+  fixtures :agreements
+
+  let(:user) { users(:user) }
+  let(:agreement) { agreements(:agreement) }
+
+  before do
+    visit '/'
+    sign_in user
+  end
+
+  scenario 'SHOW' do
+    visit agreement_path(agreement.id)
+    click_link 'Sign'
+
+    expect(page).to have_content(agreement.title)
+    expect(page).to have_content(agreement.content)
+  end
+
+  scenario 'CREATE' do
+    visit signed_agreement_path(agreement.id)
+
+    fill_in 'signed_agreement_signature', with: 'RFG'
+
+    click_on 'I Agree'
+
+    expect(page).to have_content('Agreement was successfully signed.')
+  end
+end

--- a/spec/fixtures/agreements.yml
+++ b/spec/fixtures/agreements.yml
@@ -1,0 +1,3 @@
+agreement:
+  title: "Test Agreement"
+  content: "Do you agree?"

--- a/spec/fixtures/agreements.yml
+++ b/spec/fixtures/agreements.yml
@@ -1,3 +1,3 @@
 agreement:
   title: "Test Agreement"
-  content: "Do you agree?"
+  content: "Test Content"

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Agreement do
+  fixtures :users, :agreements
+  
+  let(:user) { users(:user) }
+  let(:agreement) { agreements(:agreement) }
+
+  describe '#signed_by?' do
+    context 'when the agreement is not signed' do
+      it 'returns false' do
+        expect(agreement.signed_by?(user)).to eq false
+      end
+    end
+
+    context 'when the agreement is signed' do
+      it 'returns true' do
+        SignedAgreement.create(user: user, agreement: agreement, signature: 'RFG')
+
+        expect(agreement.signed_by?(user)).to eq true
+      end
+    end
+  end
+end

--- a/spec/models/signed_agreement_spec.rb
+++ b/spec/models/signed_agreement_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe SignedAgreement do
+  fixtures :users
+  fixtures :agreements
+
+  let(:user) { users(:user) }
+  let(:agreement) { agreements(:agreement) }
+
+  it 'is valid with valid attributes' do
+    expect(described_class.new(
+      user_id: user.id,
+      agreement_id: agreement.id,
+      signature: 'RFG'
+    )).to be_valid
+  end
+
+  it 'is not valid without a signature' do
+    expect(described_class.new(signature: nil)).to_not be_valid
+  end
+end


### PR DESCRIPTION
Resolves #31 

### Description
Adding functionality for users to be able to sign agreements.  Users need to be able to sign agreements to join organizations to start checking out carriers.
   
Also added the date signed to the show page for agreements and a checkbox on the agreements page for whether it's signed or not.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Automated browser tests