### PR TITLE
Fixes user_spec

### DIFF
--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'byebug'
 
 RSpec.describe "User" do
 
@@ -45,20 +46,23 @@ RSpec.describe "User" do
   end
 
   scenario "should send the user a welcome email" do
-    user = User.create(
-      email: "alicia@test.com",
-      password: "123abc",
-      full_name: "Alicia Barrett",
-      street_address: "123 street",
-      city: "Atlanta",
-      state: "GA",
-      postal_code: "30030",
-      phone_number: "909-851-9806")
+      Devise.mailer.deliveries = [] 
+      
+      user = User.create(
+        email: "alicia@test.com",
+        password: "123abc",
+        full_name: "Alicia Barrett",
+        street_address: "123 street",
+        city: "Atlanta",
+        state: "GA",
+        postal_code: "30030",
+        phone_number: "909-851-9806"
+      )
 
       aggregate_failures "testing welcome email" do
         expect(Devise.mailer.deliveries.count).to eq 1
         expect(Devise.mailer.deliveries.first.subject).to eq "Babywearing Account Registration"
-        expect(Devise.mailer.deliveries.first.to).to include("alicia@test.com")
+        expect(Devise.mailer.deliveries.first.to).to include(user.email)
       end
   end
 end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -45,23 +45,23 @@ RSpec.describe "User" do
   end
 
   scenario "should send the user a welcome email" do
-      Devise.mailer.deliveries = [] 
-      
-      user = User.create(
-        email: "alicia@test.com",
-        password: "123abc",
-        full_name: "Alicia Barrett",
-        street_address: "123 street",
-        city: "Atlanta",
-        state: "GA",
-        postal_code: "30030",
-        phone_number: "909-851-9806"
-      )
+    Devise.mailer.deliveries = [] 
 
-      aggregate_failures "testing welcome email" do
-        expect(Devise.mailer.deliveries.count).to eq 1
-        expect(Devise.mailer.deliveries.first.subject).to eq "Babywearing Account Registration"
-        expect(Devise.mailer.deliveries.first.to).to include(user.email)
-      end
+    user = User.create(
+      email: "alicia@test.com",
+      password: "123abc",
+      full_name: "Alicia Barrett",
+      street_address: "123 street",
+      city: "Atlanta",
+      state: "GA",
+      postal_code: "30030",
+      phone_number: "909-851-9806"
+    )
+
+    aggregate_failures "testing welcome email" do
+      expect(Devise.mailer.deliveries.count).to eq 1
+      expect(Devise.mailer.deliveries.first.subject).to eq "Babywearing Account Registration"
+      expect(Devise.mailer.deliveries.first.to).to include(user.email)
+    end
   end
 end


### PR DESCRIPTION
Resolves #70 

### Description

The test fails when Travis triggers before the user_spec the user_registration_spec, which fills the deliveries of the mailer. 

### Type of change
* Bug fix (non-breaking change which fixes an issue)
