### PR TITLE
Adding org foreign key to users table

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,4 +2,5 @@ class Organization < ApplicationRecord
   validates :name, presence: true
   has_many :locations
   has_many :carriers, through: :locations
+  has_many :users 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,4 +30,5 @@ class User < ApplicationRecord
     WelcomeMailer.welcome_email(self).deliver
   end
 
+  belongs_to :organization, optional: true
 end

--- a/db/migrate/20191003014319_add_organization_key_to_user_table.rb
+++ b/db/migrate/20191003014319_add_organization_key_to_user_table.rb
@@ -1,0 +1,5 @@
+class AddOrganizationKeyToUserTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :organization_id, :integer
+  end
+end

--- a/db/migrate/20191003014319_add_organization_key_to_user_table.rb
+++ b/db/migrate/20191003014319_add_organization_key_to_user_table.rb
@@ -1,5 +1,5 @@
 class AddOrganizationKeyToUserTable < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :organization_id, :integer
+    add_reference :users, :organization, null: true, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_28_154543) do
+ActiveRecord::Schema.define(version: 2019_10_03_014319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 2019_07_28_154543) do
     t.string "state", null: false
     t.string "postal_code", null: false
     t.string "phone_number", null: false
+    t.integer "organization_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,8 +147,9 @@ ActiveRecord::Schema.define(version: 2019_10_03_014319) do
     t.string "state", null: false
     t.string "postal_code", null: false
     t.string "phone_number", null: false
-    t.integer "organization_id"
+    t.bigint "organization_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["organization_id"], name: "index_users_on_organization_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -161,4 +162,5 @@ ActiveRecord::Schema.define(version: 2019_10_03_014319) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "users", "organizations"
 end


### PR DESCRIPTION
This will allow us to continue work on #63 

### Description


  - In order to have the organization's inventory show up as soon as a user logs in, we will need to associate them to an organization
  - TODO: We need to decide what to do with users when they first sign up. Will the homepage be a list of organizations to join if they don't already have one?



### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Migrated, rolled back, and then migrated again to make doubly sure there was nothing strange about the migration. I don't think there's any reason to unit test this change. 
