### PR TITLE
Change README for easier project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ This app uses Ruby version 2.6.3, Rails version 5.2.3, and PostgreSQL 11.4
 ### Setup
 
 - Clone the repo
-- run `bundle install`
-- run `rails db:setup`
+- run `bin/setup`
 
 ### Install ImageMagick
 

--- a/bin/setup
+++ b/bin/setup
@@ -17,20 +17,11 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
-
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
-
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  puts "\n== DONE! Go ahead and start the rails server with bin/rails server=="
 end


### PR DESCRIPTION
Instead of executing 4 commands
1. bundle install
2. bin/rails db:create
3. bin/rails db:migrate
4. bin/rails db:seed

We can just run `bin/setup` that will execute commands above for us.
