### PR TITLE
Carrier index

### DIFF
--- a/app/views/carriers/index.html.erb
+++ b/app/views/carriers/index.html.erb
@@ -4,10 +4,23 @@
 
 <h1>Carriers</h1>
 
-<ul>
-  <% @carriers.each do |carrier| %>
-    <li>
-      <%= link_to carrier.name, carrier %><br>
-    </li>
-  <% end %>
-</ul>
+<% @carriers.each_slice(4) do |carriers| %>
+  <div class="row mb-2">
+    <% carriers.each do |carrier| %>
+      <div class="col-md-3">
+        <div class="card">
+          <% if carrier.photos.attached? %>
+            <%= image_tag(carrier.photos.first.variant(resize: "200x300").processed, class: "img-thumbnail img-fluid") %>
+          <% else %>
+            <%= image_tag("img_placeholder.svg", class: "img-thumbnail img-fluid h-100") %>
+          <% end %>
+          <div class="card-body">
+            <p class="card-text"><%= carrier.name %></p>
+            <p class="card-text"><%= carrier.location.name %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -10,25 +10,5 @@
   <%= @organization.description %>
 </p>
 
-<% @organization.carriers.each_slice(4) do |carriers| %>
-  <div class="row mb-2">
-    <% carriers.each do |carrier| %>
-      <div class="col-md-3">
-        <div class="card">
-          <% if carrier.photos.attached? %>
-            <%= image_tag(carrier.photos.first.variant(resize: "200x300").processed, class: "img-thumbnail img-fluid") %>
-          <% else %>
-            <%= image_tag("img_placeholder.svg", class: "img-thumbnail img-fluid h-100") %>
-          <% end %>
-          <div class="card-body">
-            <p class="card-text"><%= carrier.name %></p>
-            <p class="card-text"><%= carrier.location.name %></p>
-          </div>
-        </div>
-      </div>
-    <% end %>
-  </div>
-<% end %>
-
 <%= link_to 'Edit', edit_organization_path(@organization) %> |
 <%= link_to 'Back', organizations_path %>


### PR DESCRIPTION
The initial implementation of a carrier inventory was in the organization#show action, which (1) does not feel right to me and (2) causes problems if we want to make the inventory the root page. Which organization should be displayed? Very weird and unclear when a user first signs up and not worth going into at this stage. We want to put off implementing organizations until we in fact have more than one organization
Looking at the commit history for these two files, it seems I am only changing an index that was there as a placeholder and returning the organization#show action to the version it was in before inventory made its way in there. Most of the code was written in pr #57, and I copy-pastad it so that it didn't depend on organization

related to #63  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not 
work as expected) -- if anyone was counting on the inventory being in the organization#show action. 

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

### Screenshots
New landing page
![image](https://user-images.githubusercontent.com/7306644/66616708-e1ac3e80-eb9f-11e9-8e93-d63225566551.png)