### PR TITLE
Add link to add new carriers in the nav bar

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
           <% end %>
         </li>
         <li class="nav-item active background-slate">
-          <a class="nav-link nav-icon nav-second" href="/"><%= image_tag "BW- ADD USER ICON.svg", alt:"Add an Item" %><p>ADD ITEM</p></a></li>
+          <a class="nav-link nav-icon nav-second" href="/carriers/new"><%= image_tag "BW- ADD USER ICON.svg", alt:"Add an Item" %><p>ADD ITEM</p></a></li>
         <li class="nav-item active background-dark-purple">
           <a class="nav-link nav-icon nav-third" href="/"><%= image_tag "BW- CART ICON.svg", alt:"Cart" %><p>CHECK IN/OUT</p></a></li>
         <li class="nav-item active background-purple">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,10 @@
           <% end %>
         </li>
         <li class="nav-item active background-slate">
-          <a class="nav-link nav-icon nav-second" href="/carriers/new"><%= image_tag "BW- ADD USER ICON.svg", alt:"Add an Item" %><p>ADD ITEM</p></a></li>
+          <%= link_to new_carrier_path, class: 'nav-link nav-icon nav-second' do %>
+            <%= image_tag "BW- ADD USER ICON.svg", alt:"Add an Item" %><p>ADD ITEM</p>
+          <% end %>
+        </li>
         <li class="nav-item active background-dark-purple">
           <a class="nav-link nav-icon nav-third" href="/"><%= image_tag "BW- CART ICON.svg", alt:"Cart" %><p>CHECK IN/OUT</p></a></li>
         <li class="nav-item active background-purple">

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -87,4 +87,17 @@ RSpec.describe 'Carrier' do
     expect(page).to have_content('Name can\'t be blank')
     expect(page).to have_content('Item can\'t be blank')
   end
+
+  scenario 'ADD new carrier' do
+    click_on 'ADD ITEM'
+
+    expect(page).to have_content('New Carrier')
+    expect(page).to have_content('Name')
+    expect(page).to have_content('Item')
+    expect(page).to have_content('Manufacturer')
+    expect(page).to have_content('Model')
+    expect(page).to have_content('Color')
+
+    expect(current_path).to eq '/carriers/new'
+  end
 end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #110 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
I've adjusted the link of the `Add Item` icon in the navigation bar to link to `/carriers/new` to create a new carrier.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->
I've added a new testcase that verify the current path in `carrier_spec.rb`. I'm also including a screenshot below.


### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->
![Screenshot from 2019-10-13 20-24-15](https://user-images.githubusercontent.com/18237025/66720024-942a0e80-edf7-11e9-828b-adf64a7ca097.png)
