### PR TITLE
Add shoulda matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :test do
   gem 'capybara'
   gem 'factory_bot_rails', '~> 5.0'
   gem 'rspec-rails', '~> 3.8'
+  gem 'shoulda-matchers', '~> 3.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    shoulda-matchers (3.0.1)
+      activesupport (>= 4.0.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -272,6 +274,7 @@ DEPENDENCIES
   rolify
   rspec-rails (~> 3.8)
   sassc-rails (~> 2.1)
+  shoulda-matchers (~> 3.0.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe Cart do
   fixtures(:users)
 
-  let(:member)    { users(:user) }
-  let(:volunteer) { users(:volunteer) }
-
-  describe '#valid?' do
-    context "with a member and a volunteer" do
-      subject { described_class.new(member: member, volunteer: volunteer) }
-
-      it 'returns true' do
-        expect(subject).to be_valid
-      end
-    end
+  context "validations" do
+    it { is_expected.to have_many(:loans) }
+    it { is_expected.to validate_presence_of(:volunteer) }
+    it { is_expected.to belong_to(:volunteer) }
+    it { is_expected.to validate_presence_of(:member) }
+    it { is_expected.to belong_to(:member) }
   end
 
   describe '#line_items' do
     fixtures(:carriers)
+
+    let(:member)    { users(:user) }
+    let(:volunteer) { users(:volunteer) }
 
     let(:carrier)  { carriers(:carrier) }
     let(:due_date) { Date.today + 1.days }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,11 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include Capybara::DSL
+
+  Shoulda::Matchers.configure do |configure|
+    configure.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
This pull request adds the `shoulda-matchers` gem to the test environment so that the tests for the class Cart are updated to test all validations, from `presence` to `have many` instead of validating an instance is valid.

Dependencies that are required for this change: `shoulda-matchers`

### Type of change
* Improve tests