### PR TITLE
Add carrier current location

### DIFF
--- a/app/controllers/carriers_controller.rb
+++ b/app/controllers/carriers_controller.rb
@@ -6,7 +6,7 @@ class CarriersController < ApplicationController
   def index
     @carriers = Carrier
                 .with_attached_photos
-                .includes(:location)
+                .includes(:home_location)
                 .all
   end
 
@@ -70,7 +70,8 @@ class CarriersController < ApplicationController
       :model,
       :color,
       :size,
-      :location_id,
+      :home_location_id,
+      :current_location_id,
       :category_id,
       :default_loan_length_days,
       photos: []

--- a/app/models/carrier.rb
+++ b/app/models/carrier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Carrier < ApplicationRecord
-  belongs_to :location
+  belongs_to :home_location, class_name: 'Location'
+  belongs_to :current_location, class_name: 'Location'
   has_many :loans
   belongs_to :category
 
@@ -9,7 +10,8 @@ class Carrier < ApplicationRecord
   validates_presence_of [
     :name,
     :item_id,
-    :location_id,
+    :home_location_id,
+    :current_location_id,
     :default_loan_length_days,
     :category_id
   ]

--- a/app/views/carriers/_carrier_form.html.erb
+++ b/app/views/carriers/_carrier_form.html.erb
@@ -30,8 +30,13 @@
   </div>
 
   <div class="form-group">
-    <%= form.label :location_id %>
-    <%= form.collection_select :location_id, @locations, :id, :name, {}, class: "form-control" %>
+    <%= form.label :home_location_id, 'Home Location' %>
+    <%= form.collection_select :home_location_id, @locations, :id, :name, {}, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :current_location_id, 'Current Location' %>
+    <%= form.collection_select :current_location_id, @locations, :id, :name, {}, class: "form-control" %>
   </div>
 
   <div class="form-group">

--- a/app/views/carriers/index.html.erb
+++ b/app/views/carriers/index.html.erb
@@ -20,7 +20,7 @@
           <% end %>
           <div class="card-body">
             <p><%= link_to carrier.name, carrier, class: "card-text" %></p>
-            <p class="card-text"><%= carrier.location.name %></p>
+            <p class="card-text"><%= carrier.home_location.name %></p>
           </div>
         </div>
       </div>

--- a/app/views/carriers/show.html.erb
+++ b/app/views/carriers/show.html.erb
@@ -11,7 +11,8 @@
   <li>Color: <%= @carrier.color %></li>
   <li>Size: <%= @carrier.size %></li>
   <li>Category: <%= @carrier.category.name %></li>
-  <li>Location: <%= @carrier.location.name %></li>
+  <li>Home Location: <%= @carrier.home_location.name %></li>
+  <li>Current Location: <%= @carrier.current_location.name %></li>
   <li>Default Loan Length: <%= @carrier.default_loan_length_days %> days</li>
   <% if @carrier.photos.attached? %>
     <li>Photos:

--- a/db/migrate/20191016050734_add_home_and_current_location_to_carrier.rb
+++ b/db/migrate/20191016050734_add_home_and_current_location_to_carrier.rb
@@ -1,0 +1,12 @@
+class AddHomeAndCurrentLocationToCarrier < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :carriers, :home_location, foreign_key: { to_table: :locations }
+    add_reference :carriers, :current_location, foreign_key: { to_table: :locations }
+
+    Carrier.all.each do |carrier|
+      carrier.update(home_location_id: carrier.location_id, current_location_id: carrier.location_id)
+    end
+
+    remove_column :carriers, :location_id, :integer
+  end
+end

--- a/db/migrate/20191016053330_require_home_and_current_location_on_carrier.rb
+++ b/db/migrate/20191016053330_require_home_and_current_location_on_carrier.rb
@@ -1,0 +1,6 @@
+class RequireHomeAndCurrentLocationOnCarrier < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :carriers, :home_location_id, false
+    change_column_null :carriers, :current_location_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_15_170701) do
+ActiveRecord::Schema.define(version: 2019_10_16_053330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,11 +50,14 @@ ActiveRecord::Schema.define(version: 2019_10_15_170701) do
     t.string "model"
     t.string "color"
     t.string "size"
-    t.integer "location_id"
     t.integer "default_loan_length_days", default: 30
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "category_id"
+    t.bigint "home_location_id", null: false
+    t.bigint "current_location_id", null: false
+    t.index ["current_location_id"], name: "index_carriers_on_current_location_id"
+    t.index ["home_location_id"], name: "index_carriers_on_home_location_id"
   end
 
   create_table "carts", force: :cascade do |t|
@@ -152,4 +155,6 @@ ActiveRecord::Schema.define(version: 2019_10_15_170701) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "carriers", "locations", column: "current_location_id"
+  add_foreign_key "carriers", "locations", column: "home_location_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,13 +81,16 @@ csv = CSV.parse(csv_text, :headers => true)
 
 csv.each do |row|
   csv_carrier = row.to_hash
+  home_location = Location.find_or_create_by(name: csv_carrier['Home Location'])
+  current_location = Location.find_or_create_by(name: csv_carrier['Current Location'])
   carrier_params = {
     name: csv_carrier['Name'],
     manufacturer: csv_carrier['Manufacturer'],
     model: csv_carrier['Model'],
     color: csv_carrier['Color'],
     size: csv_carrier['Size'],
-    location_id: Location.find_or_create_by(name: csv_carrier['Home Location']).id,
+    home_location_id: home_location.id,
+    current_location_id: (current_location || home_location).id,
     default_loan_length_days: csv_carrier['Default Loan Length'].to_i,
     category: Category.find_by(name: csv_carrier['Item Type'])
     # description: strip_tags(csv_carrier['Description'])

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -2,12 +2,15 @@
 
 RSpec.describe 'Carrier' do
   let(:category) { categories(:category) }
-  let(:location) { locations(:location) }
+  fixtures :locations
+  let(:washington) { locations(:washington) }
+  let(:lancaster) { locations(:lancaster) }
+  fixtures :carriers
   let(:carrier) { carriers(:carrier) }
   let(:user) { users(:user) }
 
   before do
-    carrier.update_attributes(location_id: location.id, category_id: category.id)
+    carrier.update_attributes(home_location: washington, current_location: washington, category_id: category.id)
 
     visit '/'
     sign_in user
@@ -27,10 +30,12 @@ RSpec.describe 'Carrier' do
 
     fill_in 'Name', with: 'Updated Name'
     fill_in 'Model', with: 'Updated Model'
+    find('#carrier_current_location_id').find(:option, lancaster.name).select_option
     click_on 'Update Carrier'
 
     expect(page).to have_content('Updated Name')
     expect(page).to have_content('Updated Model')
+    expect(page).to have_content('Lancaster')
   end
 
   scenario 'EDIT without any required fields' do

--- a/spec/fixtures/carriers.yml
+++ b/spec/fixtures/carriers.yml
@@ -6,4 +6,5 @@ carrier:
   model: "test model"
   color: "blue"
   size: 5
-  location: location
+  home_location: washington
+  current_location: lancaster

--- a/spec/fixtures/locations.yml
+++ b/spec/fixtures/locations.yml
@@ -1,2 +1,4 @@
-location:
+washington:
   name: "Washington DC"
+lancaster:
+  name: "Lancaster"

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Carrier do
-  let(:location) { locations(:location) }
+  fixtures :locations
+  let(:washington) { locations(:washington) }
+  let(:lancaster) { locations(:lancaster) }
+
+  fixtures :categories
   let(:category) { categories(:category) }
 
   it 'is valid with valid attributes' do
@@ -11,7 +15,8 @@ RSpec.describe Carrier do
       manufacturer: 'apple',
       model: 'iCarry',
       color: 'blue',
-      location_id: location.id,
+      home_location_id: washington.id,
+      current_location: lancaster,
       category_id: category.id
     )).to be_valid
   end
@@ -43,8 +48,12 @@ RSpec.describe Carrier do
     expect(described_class.new(color: nil)).to_not be_valid
   end
 
-  it 'is not valid without a location_id' do
-    expect(described_class.new(location_id: nil)).to_not be_valid
+  it 'is not valid without a home_location_id' do
+    expect(described_class.new(home_location_id: nil)).to_not be_valid
+  end
+
+  it 'is not valid without a current_location_id' do
+    expect(described_class.new(current_location_id: nil)).to_not be_valid
   end
 
   describe '#build_loan' do


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #108

### Description
Add a current location to a carrier to distinguish between home location.

Rename existing `location_id` to `home_location_id` and add a new `current_location_id`. Populate  current location with home location initially

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- Updated test for carrier model.
- Updated carrier feature test.

### Screenshots
`/carriers/new`, `/carriers/:id/edit`
![image](https://user-images.githubusercontent.com/478300/66727752-06015880-edf6-11e9-8ac7-fcb472e2739a.png)

`/carriers/:id`
![image](https://user-images.githubusercontent.com/478300/66803179-b98c4a80-eed3-11e9-83b9-b21ece951b5e.png)
