### PR TITLE
Add links for users to select specific carriers

### DIFF
--- a/app/views/carriers/index.html.erb
+++ b/app/views/carriers/index.html.erb
@@ -10,12 +10,16 @@
       <div class="col-md-3">
         <div class="card">
           <% if carrier.photos.attached? %>
-            <%= image_tag(carrier.photos.first.variant(resize: "200x300").processed, class: "img-thumbnail img-fluid") %>
+            <%= link_to carrier do %>
+              <%= image_tag(carrier.photos.first.variant(resize: "200x300").processed, class: "img-thumbnail img-fluid") %>
+            <% end %>
           <% else %>
-            <%= image_tag("img_placeholder.svg", class: "img-thumbnail img-fluid h-100") %>
+            <%= link_to carrier do %>
+              <%= image_tag("img_placeholder.svg", class: "img-thumbnail img-fluid h-100") %>
+            <% end %>
           <% end %>
           <div class="card-body">
-            <p class="card-text"><%= carrier.name %></p>
+            <p class="card-text"><%= link_to carrier.name, carrier %></p>
             <p class="card-text"><%= carrier.location.name %></p>
           </div>
         </div>


### PR DESCRIPTION
When users are viewing the list of carriers, there are currently no
links on any of the cards for them to view more details about the
carrier they are interested in. This change adds links so the name of
the carrier along with the photo are clickable.

This also resolves a broken feature test which expects a link with the
content of a carrier name to exist.