### PR TITLE
[Bug] Show parent name instead of obbject

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -25,7 +25,7 @@
 
 <p>
   <strong>Parent:</strong>
-  <%= @category.parent %>
+  <%= @category.parent&.name %>
 </p>
 
 <%= link_to 'Edit', edit_category_path(@category) %> |


### PR DESCRIPTION
### Description
When on show page of category, we print parent object instead of parent object name. 

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

### Screenshots
Before
<img width="1124" alt="Screenshot 2019-10-15 at 1 48 17 AM" src="https://user-images.githubusercontent.com/8337530/66780303-26144300-eeee-11e9-8601-2d57cfcfb63c.png">

After
<img width="1017" alt="Screenshot 2019-10-15 at 1 48 00 AM" src="https://user-images.githubusercontent.com/8337530/66780302-26144300-eeee-11e9-8873-61a8b8090b65.png">
