### PR TITLE
Fix flaky carrier specs

### DIFF
--- a/spec/features/category_spec.rb
+++ b/spec/features/category_spec.rb
@@ -3,11 +3,12 @@
 RSpec.feature "category" do
   fixtures :categories
   fixtures :carriers
+  fixtures :locations
   fixtures :users
-  
+
   let!(:category) { categories(:category_parent) }
   let!(:category_child) { categories(:category) }
-  let!(:carrier) { carriers(:carrier) } 
+  let!(:carrier) { carriers(:carrier) }
   let(:user) { users(:user) }
 
   before :each do
@@ -43,11 +44,11 @@ RSpec.feature "category" do
     expect(page).to have_content "Category was successfully destroyed."
   end
 
-  scenario 'should show carriers for category as a link' do 
+  scenario 'should show carriers for category as a link' do
     visit category_path(category)
     expect(page).to have_content(category.name)
     find_link(carrier.name).click
-    expect(page).to have_current_path(carrier_path(carrier))   
+    expect(page).to have_current_path(carrier_path(carrier))
   end
 
   scenario 'should show a empty message if category has no carriers' do

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Cart do
 
   describe '#line_items' do
     fixtures(:carriers)
+    fixtures(:locations)
 
     let(:carrier)  { carriers(:carrier) }
     let(:due_date) { Date.today + 1.days }

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Loan do
-  fixtures(:carriers, :users)
+  fixtures(:carriers, :users, :locations)
 
   let(:member)    { users(:user) }
   let(:volunteer) { users(:volunteer) }


### PR DESCRIPTION
Resolves #139

We have had multiple times where builds would fail, mostly on `carrier.location.name` with a `undefined method name for nil`. Seems like the reason for it is that location fixtures were not enabled when the carrier fixtures were, so carriers would be created without locations.

I do not like this fix, nor do I like fixtures, but this should resolve our issues for the time being. Maybe we should enable `fixtures :all` to avoid this issue? I've always avoided fixtures as they introduced weird behavior, but had no idea it can get weird like this.