### PR TITLE
Load all the fixtures all the time.

### DIFF
--- a/spec/features/agreement_spec.rb
+++ b/spec/features/agreement_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature 'create an agreement', type: :feature do
-  fixtures :users, :agreements
   let(:user) { users(:user) }
   let(:agreement) { agreements(:agreement) }
 

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Carrier' do
-  fixtures :categories
   let(:category) { categories(:category) }
-  fixtures :locations
   let(:location) { locations(:location) }
-  fixtures :carriers
   let(:carrier) { carriers(:carrier) }
-  fixtures :users
   let(:user) { users(:user) }
 
   before do

--- a/spec/features/category_spec.rb
+++ b/spec/features/category_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "category" do
-  fixtures :categories
-  fixtures :carriers
-  fixtures :locations
-  fixtures :users
-
   let!(:category) { categories(:category_parent) }
   let!(:category_child) { categories(:category) }
   let!(:carrier) { carriers(:carrier) }

--- a/spec/features/fee_type_spec.rb
+++ b/spec/features/fee_type_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "fee_type" do
-  fixtures :users
   let(:user) { users(:user) }
 
   before :each do

--- a/spec/features/location_spec.rb
+++ b/spec/features/location_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature 'create a location', type: :feature do
-  fixtures :users
   let(:user) { users(:user) }
 
   before :each do

--- a/spec/features/membership_type_spec.rb
+++ b/spec/features/membership_type_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe 'MembershipType', type: :feature do
-  fixtures :users
   let(:user) { users(:user) }
 
   before(:each) do

--- a/spec/features/signed_agreement_spec.rb
+++ b/spec/features/signed_agreement_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe SignedAgreement do
-  fixtures :users
-  fixtures :agreements
-
   let(:user) { users(:user) }
   let(:agreement) { agreements(:agreement) }
 

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe "User" do
-
-  fixtures :users
   let(:user) { users(:user) }
 
   scenario "should allow user who is an admin to see list of users" do

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Agreement do
-  fixtures :users, :agreements
-  
   let(:user) { users(:user) }
   let(:agreement) { agreements(:agreement) }
 

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Carrier do
-  fixtures :locations
   let(:location) { locations(:location) }
-
-  fixtures :categories
   let(:category) { categories(:category) }
 
   it 'is valid with valid attributes' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Category, type: :model do
-  fixtures :categories
   let!(:category) { categories(:category) }
 
   it "should be unique" do

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Loan do
-  fixtures(:carriers, :users, :locations)
-
   let(:member)    { users(:user) }
   let(:volunteer) { users(:volunteer) }
 

--- a/spec/models/signed_agreement_spec.rb
+++ b/spec/models/signed_agreement_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe SignedAgreement do
-  fixtures :users
-  fixtures :agreements
-
   let(:user) { users(:user) }
   let(:agreement) { agreements(:agreement) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -44,6 +45,7 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+  config.global_fixtures = :all
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
Make all the fixtures globally accessible without the need to call `fixtures` method in each spec.
It achieves that by setting `config.global_fixtures = :all` inside the rspec config