### PR TITLE
Fix button styling for carrier form

### DIFF
--- a/app/views/carriers/_carrier_form.html.erb
+++ b/app/views/carriers/_carrier_form.html.erb
@@ -58,8 +58,8 @@
   </div>
 
   <div class="form-group">
-    <%= form.label :photos %>
-    <%= form.file_field :photos, multiple: true, class: "form-control" %>
+    <%= form.label :photos, class: "pl-1 mb-0" %>
+    <%= form.file_field :photos, multiple: true, class: "btn pl-1 form-control" %>
   </div>
 
   <%= form.submit class: "btn btn-primary" %>


### PR DESCRIPTION
Just a quick styling fix using bootstrap utility classes for the carrier form. Removes the bordered field for the file attachments element and aligns it with the label.
Resolves #146