### PR TITLE
fix typo in cc_test_reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 env:
   global:
-    - CC_TEST_REPORTER=b80cc9abeed21ed522cf2d3831da7ed52dfd6e18bdce2ade4125fd033e96a951
+    - CC_TEST_REPORTER_ID=b80cc9abeed21ed522cf2d3831da7ed52dfd6e18bdce2ade4125fd033e96a951
 language: ruby
 rvm:
   - 2.6.3


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description

Resolves a silly typo in `.travis.yml` -> `CC_TEST_REPORTER_ID` (guess it actually needs `_ID`)

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested on [my fork](https://github.com/abronkema/babywearing) and verified Test Coverage is accurately reported in Code Climate (screenshot below).

### Screenshots

![image](https://user-images.githubusercontent.com/47750744/67313379-de368280-f4d0-11e9-9492-e303d78e1d82.png)
