### PR TITLE
Fix: Problem on login and add login/out specs

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -8,30 +8,26 @@
           </div>
 
           <%= form_with model: resource, as: resource_name, url: session_path(resource_name), html: { class: "user" }, local: true do |f| %>
-          <div class="form-group">
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control form-control-user', aria: { label: 'email'}, placeholder: 'Enter email address' %>
-          </div>
-
-          <div class="form-group">
-            <%= f.password_field :password, autocomplete: "current-password", class: 'form-control form-control-user', aria: { label: 'password'}, placeholder: 'Password' %>
-          </div>
+            <div class="form-group">
+              <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control form-control-user', aria: { label: 'email'}, placeholder: 'Enter email address' %>
+            </div>
 
             <div class="form-group">
               <%= f.password_field :password, autocomplete: "current-password", class: 'form-control form-control-user', aria: { label: 'password'}, placeholder: 'Password' %>
             </div>
 
-            <% if devise_mapping.rememberable? %>
-              <div class="form-group">
-                <div class="custom-control custom-checkbox small">
-                  <%= f.check_box :remember_me, id: 'customCheck', class: 'custom-control-input', aria: { label: 'remember me'} %>
-                  <%= f.label 'Remember Me', for: 'customCheck', class: 'custom-control-label' %>
+              <% if devise_mapping.rememberable? %>
+                <div class="form-group">
+                  <div class="custom-control custom-checkbox small">
+                    <%= f.check_box :remember_me, id: 'customCheck', class: 'custom-control-input', aria: { label: 'remember me'} %>
+                    <%= f.label 'Remember Me', for: 'customCheck', class: 'custom-control-label' %>
+                  </div>
                 </div>
-              </div>
-            <% end %>
+              <% end %>
 
-            <div class="actions">
-              <%= f.submit "Log In", class: "btn btn-primary btn-user btn-block" %>
-            </div>
+              <div class="actions">
+                <%= f.submit "Log In", class: "btn btn-primary btn-user btn-block" %>
+              </div>
           <% end %>
 
           <hr />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  devise_for :users, controllers: { registrations: "users/registrations" }
+
   resources :signed_agreements, only: [:show, :create]
   resources :fee_types
   resources :agreements
@@ -7,7 +9,6 @@ Rails.application.routes.draw do
   resources :users, only: [:index]
   resources :carriers
   resources :photos, only: :destroy
-  devise_for :users, controllers: { registrations: "users/registrations" }
   get 'home/index'
 
   resources :categories

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe 'User signs out', type: :feature do
+  scenario "signs out" do
+    user = users(:member)
+    sign_in user
+    visit root_url
+
+    sign_out
+
+    user_should_be_signed_out
+  end
+end

--- a/spec/features/visitor_signs_in_spec.rb
+++ b/spec/features/visitor_signs_in_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Visitor signs in', type: :feature do
+  VALID_PASSWORD = "password"
+
+  let(:user) { users(:member) }
+
+  scenario "with valid email and password" do
+    sign_in_with email: user.email, password: VALID_PASSWORD
+    user_should_be_signed_in
+  end
+
+  scenario "with invalid email" do
+    sign_in_with email: "invalid.email@exmaple.org", password: VALID_PASSWORD
+    user_should_be_signed_out
+    expect(page).to have_content "Invalid Email or password."
+  end
+
+  scenario "with invalid password" do
+    sign_in_with email: user.email, password: "invalid_password"
+    user_should_be_signed_out
+    expect(page).to have_content "Invalid Email or password."
+  end
+end

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,6 +1,6 @@
 user:
   email: 'hello@test.com'
-  encrypted_password: 'password'
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
   full_name: 'Pineapple'
   street_address: '123 main street'
   city: 'fairfax'
@@ -10,7 +10,7 @@ user:
 
 volunteer:
   email: 'volunteer@test.com'
-  encrypted_password: 'password'
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
   full_name: 'Volunteer'
   street_address: '123 main street'
   city: 'fairfax'
@@ -21,7 +21,7 @@ volunteer:
 
 admin:
   email: 'admin@test.com'
-  encrypted_password: 'password'
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
   full_name: 'Admin User'
   street_address: '123 main street'
   city: 'fairfax'
@@ -32,7 +32,7 @@ admin:
 
 member:
   email: 'member@test.com'
-  encrypted_password: 'password'
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
   full_name: 'Memebr'
   street_address: '123 main street'
   city: 'fairfax'

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Dir[Rails.root.join('spec/support/features/*.rb')].each { |f| require f }
+
+RSpec.configure do |config|
+  config.include Features, type: :feature
+end
+

--- a/spec/support/features/devise_helpers.rb
+++ b/spec/support/features/devise_helpers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Features
+  def sign_in_with(email:, password:)
+    visit new_user_session_path
+    fill_in 'user_email', :with => email
+    fill_in 'user_password', :with => password
+    click_button "Log In"
+  end
+
+  def sign_out
+    click_link "Logout"
+  end
+
+  def user_should_be_signed_in
+    visit root_path
+    expect(page).to have_content "Logout"
+  end
+
+  def user_should_be_signed_out
+    expect(page).to have_content "Log In"
+  end
+end


### PR DESCRIPTION
By mistake we had 2 password fields on the login, this removes unnecessary
double password field.

Also, to prevent similar cases in the future I've written specs for login and logout.
In the process I needed to change the way how we add password inside the
fixtures to be correctly hashed value.