### PR TITLE
#175 - Adds RBAC for Carrier model. 

### DIFF
--- a/app/controllers/carriers_controller.rb
+++ b/app/controllers/carriers_controller.rb
@@ -41,8 +41,8 @@ class CarriersController < ApplicationController
   end
 
   def update
-    @carrier.update(carrier_params)
     authorize @carrier
+    @carrier.update(carrier_params)
     if @carrier.errors.any?
       flash[:errors] = @carrier.errors.full_messages
       redirect_to edit_carrier_path(@carrier)

--- a/app/controllers/carriers_controller.rb
+++ b/app/controllers/carriers_controller.rb
@@ -17,10 +17,12 @@ class CarriersController < ApplicationController
     @carrier = Carrier.new
     @locations = Location.all
     @categories = Category.all
+    authorize @carrier
   end
 
   def create
     @carrier = Carrier.new(carrier_params)
+    authorize @carrier
     @carrier.save
 
     if @carrier.errors.any?
@@ -35,11 +37,12 @@ class CarriersController < ApplicationController
   def edit
     @locations = Location.all
     @categories = Category.all
+    authorize @carrier
   end
 
   def update
     @carrier.update(carrier_params)
-
+    authorize @carrier
     if @carrier.errors.any?
       flash[:errors] = @carrier.errors.full_messages
       redirect_to edit_carrier_path(@carrier)
@@ -51,7 +54,9 @@ class CarriersController < ApplicationController
 
   def destroy
     @carrier = Carrier.find(params[:id])
+    authorize @carrier
     @carrier.destroy
+
     flash[:success] = 'Carrier successfully destroyed'
     redirect_to carriers_path
   end

--- a/app/policies/carrier_policy.rb
+++ b/app/policies/carrier_policy.rb
@@ -1,0 +1,33 @@
+class CarrierPolicy < ApplicationPolicy
+  attr_reader :user, :members
+
+  def initialize(user, members)
+    @user = user
+    @members = members
+  end
+
+  def create?
+    roles = [:admin, :volunteer]
+    authorized?(roles)
+  end
+
+  def update?
+    roles = [:admin, :volunteer]
+    authorized?(roles)
+  end
+
+  def destroy?
+    roles = [:admin, :volunteer]
+    authorized?(roles)
+  end
+
+  private
+    def authorized?(roles)
+      for role in roles
+        if user.has_role?(role)
+          return true
+        end
+      end
+      return false
+    end
+end

--- a/app/policies/carrier_policy.rb
+++ b/app/policies/carrier_policy.rb
@@ -1,12 +1,22 @@
 class CarrierPolicy < ApplicationPolicy
-  attr_reader :user, :members
+  attr_reader :user, :carrier
 
-  def initialize(user, members)
+  def initialize(user, carrier)
     @user = user
-    @members = members
+    @carrier = carrier
+  end
+
+  def new?
+    roles = [:admin, :volunteer]
+    authorized?(roles)
   end
 
   def create?
+    roles = [:admin, :volunteer]
+    authorized?(roles)
+  end
+
+  def edit?
     roles = [:admin, :volunteer]
     authorized?(roles)
   end
@@ -23,11 +33,6 @@ class CarrierPolicy < ApplicationPolicy
 
   private
     def authorized?(roles)
-      for role in roles
-        if user.has_role?(role)
-          return true
-        end
-      end
-      return false
+      @user.has_any_role?(*roles)
     end
 end

--- a/app/views/carriers/show.html.erb
+++ b/app/views/carriers/show.html.erb
@@ -23,7 +23,7 @@
   <% end %>
 </ul>
 
-<% if policy(@carrier).update? %>
+<% if policy(@carrier).edit? %>
   <%= link_to 'Edit', edit_carrier_path %>
 <% end %>
 

--- a/app/views/carriers/show.html.erb
+++ b/app/views/carriers/show.html.erb
@@ -23,5 +23,10 @@
   <% end %>
 </ul>
 
-<%= link_to 'Edit', edit_carrier_path %>
-<%= link_to 'Delete', @carrier, method: :delete  %>
+<% if policy(@carrier).update? %>
+  <%= link_to 'Edit', edit_carrier_path %>
+<% end %>
+
+<% if policy(@carrier).destroy? %>
+  <%= link_to 'Delete', @carrier, method: :delete  %>
+<% end %>

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Carrier USER role' do
     expect(page).to have_content('test model')
   end
 
-  scenario 'CREATE' do
+  scenario 'NEW' do
     visit new_carrier_path
 
     expect(page).to have_content "Sorry, you aren't allowed to do that."
@@ -42,6 +42,133 @@ RSpec.describe 'Carrier ADMIN role' do
   before do
     visit '/'
     sign_in user
+  end
+
+  scenario 'SHOW' do
+    visit carriers_path
+    click_link carrier.name
+
+    expect(page).to have_content('test carrier')
+    expect(page).to have_content('babywearing')
+    expect(page).to have_content('test model')
+  end
+
+  scenario 'NEW' do
+    visit new_carrier_path
+    fill_in 'Name', with: 'Test Name'
+    fill_in 'Item', with: 9
+    fill_in 'Manufacturer', with: 'Test Manufacturer'
+    fill_in 'Model', with: 'Test Model'
+    fill_in 'Color', with: 'White'
+    find('#carrier_category_id').find(:option, category.name).select_option
+
+    click_on 'Create Carrier'
+
+    expect(page).to have_content('Carrier successfully created')
+  end
+
+  scenario 'EDIT with all required fields' do
+    visit edit_carrier_path(carrier.id)
+
+    fill_in 'Name', with: 'Updated Name'
+    fill_in 'Model', with: 'Updated Model'
+    find('#carrier_current_location_id').find(:option, lancaster.name).select_option
+    click_on 'Update Carrier'
+
+    expect(page).to have_content('Updated Name')
+    expect(page).to have_content('Updated Model')
+    expect(page).to have_content('Lancaster')
+  end
+
+  scenario 'EDIT without any required fields' do
+    visit edit_carrier_path(carrier.id)
+
+    fill_in 'Name', with: nil
+    fill_in 'Item', with: nil
+    click_on 'Update Carrier'
+
+    expect(page).to have_content('Name can\'t be blank')
+    expect(page).to have_content('Item can\'t be blank')
+  end
+
+  scenario 'DESTROY' do
+    visit carrier_path(carrier.id)
+
+    click_on 'Delete'
+    expect(page).to have_content('Carrier successfully destroyed')
+  end
+
+  scenario 'CREATE with all required fields' do
+    visit new_carrier_path
+    fill_in 'Name', with: 'Test Name'
+    fill_in 'Item', with: 9
+    fill_in 'Manufacturer', with: 'Test Manufacturer'
+    fill_in 'Model', with: 'Test Model'
+    fill_in 'Color', with: 'White'
+    find('#carrier_category_id').find(:option, category.name).select_option
+
+    click_on 'Create Carrier'
+
+    expect(page).to have_content('Carrier successfully created')
+  end
+
+  scenario 'CREATE with duplicated item_id' do
+    visit new_carrier_path
+    fill_in 'Item', with: carrier.item_id
+
+    click_on 'Create Carrier'
+
+    expect(page).to have_content('Item ID has already been taken')
+  end
+
+  scenario 'CREATE without required fields' do
+    visit new_carrier_path(carrier.id)
+
+    click_on 'Create Carrier'
+
+    expect(page).to have_content('Name can\'t be blank')
+    expect(page).to have_content('Item can\'t be blank')
+  end
+
+  scenario 'ADD new carrier' do
+    visit '/'
+    click_on 'ADD ITEM'
+
+    expect(page).to have_content('New Carrier')
+    expect(page).to have_content('Name')
+    expect(page).to have_content('Item')
+    expect(page).to have_content('Manufacturer')
+    expect(page).to have_content('Model')
+    expect(page).to have_content('Color')
+
+    expect(current_path).to eq '/carriers/new'
+  end
+end
+
+RSpec.describe 'Carrier VOLUNTEER role' do
+  let(:category) { categories(:category) }
+  let(:washington) { locations(:washington) }
+  let(:lancaster) { locations(:lancaster) }
+  let(:carrier) { carriers(:carrier) }
+  let(:user) { users(:volunteer) }
+
+  before do
+    visit '/'
+    sign_in user
+  end
+
+  scenario 'NEW' do
+    visit new_carrier_path
+    fill_in 'Name', with: 'Test Name'
+    fill_in 'Item', with: 9
+    fill_in 'Manufacturer', with: 'Test Manufacturer'
+    fill_in 'Model', with: 'Test Model'
+    fill_in 'Color', with: 'White'
+    find('#carrier_category_id').find(:option, category.name).select_option
+
+    click_on 'Create Carrier'
+
+    expect(page).to have_content('Carrier successfully created')
   end
 
   scenario 'SHOW' do
@@ -129,4 +256,36 @@ RSpec.describe 'Carrier ADMIN role' do
 
     expect(current_path).to eq '/carriers/new'
   end
+end
+
+RSpec.describe 'Carrier MEMBER role' do
+  let(:carrier) { carriers(:carrier) }
+  let(:user) { users(:member) }
+
+  before do
+    visit '/'
+    sign_in user
+  end
+
+  scenario 'SHOW' do
+    visit carriers_path
+    click_link carrier.name
+
+    expect(page).to have_content('test carrier')
+    expect(page).to have_content('babywearing')
+    expect(page).to have_content('test model')
+  end
+
+  scenario 'NEW' do
+    visit new_carrier_path
+
+    expect(page).to have_content "Sorry, you aren't allowed to do that."
+  end
+
+  scenario 'EDIT' do
+    visit edit_carrier_path(carrier.id)
+
+    expect(page).to have_content "Sorry, you aren't allowed to do that."
+  end
+
 end

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -55,16 +55,14 @@ RSpec.describe 'Carrier ADMIN role' do
 
   scenario 'NEW' do
     visit new_carrier_path
-    fill_in 'Name', with: 'Test Name'
-    fill_in 'Item', with: 9
-    fill_in 'Manufacturer', with: 'Test Manufacturer'
-    fill_in 'Model', with: 'Test Model'
-    fill_in 'Color', with: 'White'
-    find('#carrier_category_id').find(:option, category.name).select_option
+    expect(page).to have_content('New Carrier')
+    expect(page).to have_content('Name')
+    expect(page).to have_content('Item')
+    expect(page).to have_content('Manufacturer')
+    expect(page).to have_content('Model')
+    expect(page).to have_content('Color')
 
-    click_on 'Create Carrier'
-
-    expect(page).to have_content('Carrier successfully created')
+    expect(current_path).to eq '/carriers/new'
   end
 
   scenario 'EDIT with all required fields' do
@@ -159,16 +157,15 @@ RSpec.describe 'Carrier VOLUNTEER role' do
 
   scenario 'NEW' do
     visit new_carrier_path
-    fill_in 'Name', with: 'Test Name'
-    fill_in 'Item', with: 9
-    fill_in 'Manufacturer', with: 'Test Manufacturer'
-    fill_in 'Model', with: 'Test Model'
-    fill_in 'Color', with: 'White'
-    find('#carrier_category_id').find(:option, category.name).select_option
 
-    click_on 'Create Carrier'
+    expect(page).to have_content('New Carrier')
+    expect(page).to have_content('Name')
+    expect(page).to have_content('Item')
+    expect(page).to have_content('Manufacturer')
+    expect(page).to have_content('Model')
+    expect(page).to have_content('Color')
 
-    expect(page).to have_content('Carrier successfully created')
+    expect(current_path).to eq '/carriers/new'
   end
 
   scenario 'SHOW' do

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -1,11 +1,43 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Carrier' do
+RSpec.describe 'Carrier USER role' do
+  let(:carrier) { carriers(:carrier) }
+  let(:user) { users(:user) }
+
+  before do
+    visit '/'
+    sign_in user
+  end
+
+  scenario 'SHOW' do
+    visit carriers_path
+    click_link carrier.name
+
+    expect(page).to have_content('test carrier')
+    expect(page).to have_content('babywearing')
+    expect(page).to have_content('test model')
+  end
+
+  scenario 'CREATE' do
+    visit new_carrier_path
+
+    expect(page).to have_content "Sorry, you aren't allowed to do that."
+  end
+
+  scenario 'EDIT' do
+    visit edit_carrier_path(carrier.id)
+
+    expect(page).to have_content "Sorry, you aren't allowed to do that."
+  end
+
+end
+
+RSpec.describe 'Carrier ADMIN role' do
   let(:category) { categories(:category) }
   let(:washington) { locations(:washington) }
   let(:lancaster) { locations(:lancaster) }
   let(:carrier) { carriers(:carrier) }
-  let(:user) { users(:user) }
+  let(:user) { users(:admin) }
 
   before do
     visit '/'
@@ -49,7 +81,6 @@ RSpec.describe 'Carrier' do
     visit carrier_path(carrier.id)
 
     click_on 'Delete'
-
     expect(page).to have_content('Carrier successfully destroyed')
   end
 

--- a/spec/policies/carrier_policy.spec.rb
+++ b/spec/policies/carrier_policy.spec.rb
@@ -4,37 +4,24 @@ require 'rails_helper'
 
 describe CarrierPolicy do
 
-  let(:admin_user) {
-    user = User.new()
-    user.add_role(:admin)
-    user
-  }
-
-  let(:non_admin_or_volunteer_user) {
-    user = User.new()
-    user
-  }
-
-  let(:volunteer_user) {
-    user = User.new()
-    user.add_role(:volunteer)
-    user
-  }
+  let(:admin) { users(:admin) }
+  let(:volunteer) { users(:volunteer) }
+  let(:member) { users(:member) }
 
   subject(:instance) { described_class }
 
   permissions :create? do
 
     it "denies access if user is not an admin or volunteer" do
-      expect(subject).not_to permit(non_admin_or_volunteer_user)
+      expect(subject).not_to permit(member)
     end
 
     it "grants access if the user is an admin" do
-      expect(subject).to permit(admin_user)
+      expect(subject).to permit(admin)
     end
 
     it "grants access if the user is a volunteer" do
-      expect(subject).to permit(volunteer_user)
+      expect(subject).to permit(volunteer)
     end
 
   end
@@ -42,15 +29,15 @@ describe CarrierPolicy do
   permissions :update? do
 
     it "denies access if user is not an admin or volunteer" do
-      expect(subject).not_to permit(non_admin_or_volunteer_user)
+      expect(subject).not_to permit(member)
     end
 
     it "grants access if the user is an admin" do
-      expect(subject).to permit(admin_user)
+      expect(subject).to permit(admin)
     end
 
     it "grants access if the user is a volunteer" do
-      expect(subject).to permit(volunteer_user)
+      expect(subject).to permit(volunteer)
     end
 
   end
@@ -58,15 +45,15 @@ describe CarrierPolicy do
   permissions :destroy? do
 
     it "denies access if user is not an admin or volunteer" do
-      expect(subject).not_to permit(non_admin_or_volunteer_user)
+      expect(subject).not_to permit(member)
     end
 
     it "grants access if the user is an admin" do
-      expect(subject).to permit(admin_user)
+      expect(subject).to permit(admin)
     end
 
     it "grants access if the user is a volunteer" do
-      expect(subject).to permit(volunteer_user)
+      expect(subject).to permit(volunteer)
     end
 
   end

--- a/spec/policies/carrier_policy.spec.rb
+++ b/spec/policies/carrier_policy.spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CarrierPolicy do
+
+  let(:admin_user) {
+    user = User.new()
+    user.add_role(:admin)
+    user
+  }
+
+  let(:non_admin_or_volunteer_user) {
+    user = User.new()
+    user
+  }
+
+  let(:volunteer_user) {
+    user = User.new()
+    user.add_role(:volunteer)
+    user
+  }
+
+  subject(:instance) { described_class }
+
+  permissions :create? do
+
+    it "denies access if user is not an admin or volunteer" do
+      expect(subject).not_to permit(non_admin_or_volunteer_user)
+    end
+
+    it "grants access if the user is an admin" do
+      expect(subject).to permit(admin_user)
+    end
+
+    it "grants access if the user is a volunteer" do
+      expect(subject).to permit(volunteer_user)
+    end
+
+  end
+
+  permissions :update? do
+
+    it "denies access if user is not an admin or volunteer" do
+      expect(subject).not_to permit(non_admin_or_volunteer_user)
+    end
+
+    it "grants access if the user is an admin" do
+      expect(subject).to permit(admin_user)
+    end
+
+    it "grants access if the user is a volunteer" do
+      expect(subject).to permit(volunteer_user)
+    end
+
+  end
+
+  permissions :destroy? do
+
+    it "denies access if user is not an admin or volunteer" do
+      expect(subject).not_to permit(non_admin_or_volunteer_user)
+    end
+
+    it "grants access if the user is an admin" do
+      expect(subject).to permit(admin_user)
+    end
+
+    it "grants access if the user is a volunteer" do
+      expect(subject).to permit(volunteer_user)
+    end
+
+  end
+end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #175 <!--fill issue number-->

### Description

This fix uses the already-installed gem named pundit (https://github.com/varvet/pundit). I created a new policy for the carrier model. For each action you can customize which roles are authorized to perform update, destroy and create actions, as for now, as requested, only admins and volunteers are allowed to do so. Also, if the user does not have privilege, the "edit" and "delete" buttons won't show on the carrier view.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I added new tests so I can perform the same actions as both user and admin roles.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->