### PR TITLE
Feature/add status to carriers

### DIFF
--- a/app/controllers/carriers_controller.rb
+++ b/app/controllers/carriers_controller.rb
@@ -80,6 +80,7 @@ class CarriersController < ApplicationController
       :current_location_id,
       :category_id,
       :default_loan_length_days,
+      :status,
       photos: []
     )
   end

--- a/app/models/carrier.rb
+++ b/app/models/carrier.rb
@@ -18,6 +18,15 @@ class Carrier < ApplicationRecord
 
   has_many_attached :photos
 
+  enum status: {
+    available: 0,
+    unavailable: 1,
+    disabled: 2,
+    sold: 4
+  }
+
+  alias_method :available_for_checkout?, :available?
+
   def build_loan(attributes = {})
     loans.create({
       due_date: Date.today + default_loan_length_days.days,

--- a/app/models/carrier.rb
+++ b/app/models/carrier.rb
@@ -27,10 +27,6 @@ class Carrier < ApplicationRecord
 
   alias_method :available_for_checkout?, :available?
 
-  def self.options_for_status_select
-    self.statuses.map { |status, _| [status.titleize, status] }
-  end
-
   def build_loan(attributes = {})
     loans.create({
       due_date: Date.today + default_loan_length_days.days,

--- a/app/models/carrier.rb
+++ b/app/models/carrier.rb
@@ -27,6 +27,10 @@ class Carrier < ApplicationRecord
 
   alias_method :available_for_checkout?, :available?
 
+  def self.options_for_status_select
+    self.statuses.map { |status, _| [status.titleize, status] }
+  end
+
   def build_loan(attributes = {})
     loans.create({
       due_date: Date.today + default_loan_length_days.days,

--- a/app/models/carrier.rb
+++ b/app/models/carrier.rb
@@ -22,7 +22,7 @@ class Carrier < ApplicationRecord
     available: 0,
     unavailable: 1,
     disabled: 2,
-    sold: 4
+    sold: 3
   }
 
   alias_method :available_for_checkout?, :available?

--- a/app/views/carriers/_carrier_form.html.erb
+++ b/app/views/carriers/_carrier_form.html.erb
@@ -50,6 +50,11 @@
   </div>
 
   <div class="form-group">
+    <%= form.label :status %>
+    <%= form.select :status, Carrier.options_for_status_select, {}, { class: "form-control" } %>
+  </div>
+
+  <div class="form-group">
     <%= form.label :default_loan_length_days, 'Default Loan Length' %>
     <%= form.number_field :default_loan_length_days, class: "form-control" %> days
   </div>

--- a/app/views/carriers/_carrier_form.html.erb
+++ b/app/views/carriers/_carrier_form.html.erb
@@ -51,7 +51,7 @@
 
   <div class="form-group">
     <%= form.label :status %>
-    <%= form.select :status, Carrier.options_for_status_select, {}, { class: "form-control" } %>
+    <%= form.select :status, Carrier.statuses.keys.map { |key| [key.titleize, key] }, {}, { class: "form-control" } %>
   </div>
 
   <div class="form-group">

--- a/app/views/carriers/show.html.erb
+++ b/app/views/carriers/show.html.erb
@@ -14,8 +14,8 @@
   <li>Category: <%= @carrier.category.name %></li>
   <li>Home Location: <%= @carrier.home_location.name %></li>
   <li>Current Location: <%= @carrier.current_location.name %></li>
-  <li>Default Loan Length: <%= @carrier.default_loan_length_days %> days</li>
   <li>Status: <%= @carrier.status.titleize %>
+  <li>Default Loan Length: <%= @carrier.default_loan_length_days %> days</li>
   <% if @carrier.photos.attached? %>
     <li>Photos:
       <% @carrier.photos.each do |photo| %>

--- a/app/views/carriers/show.html.erb
+++ b/app/views/carriers/show.html.erb
@@ -15,6 +15,7 @@
   <li>Home Location: <%= @carrier.home_location.name %></li>
   <li>Current Location: <%= @carrier.current_location.name %></li>
   <li>Default Loan Length: <%= @carrier.default_loan_length_days %> days</li>
+  <li>Status: <%= @carrier.status.titleize %>
   <% if @carrier.photos.attached? %>
     <li>Photos:
       <% @carrier.photos.each do |photo| %>

--- a/db/migrate/20191023030308_add_status_to_carriers.rb
+++ b/db/migrate/20191023030308_add_status_to_carriers.rb
@@ -1,0 +1,7 @@
+class AddStatusToCarriers < ActiveRecord::Migration[5.2]
+  def change
+    change_table :carriers do |t|
+      t.column :status, :integer, default: 0, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2019_10_24_165716) do
     t.bigint "home_location_id", null: false
     t.bigint "current_location_id", null: false
     t.string "safety_link"
+    t.integer "status", default: 0, null: false
     t.index ["current_location_id"], name: "index_carriers_on_current_location_id"
     t.index ["home_location_id"], name: "index_carriers_on_home_location_id"
   end

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -72,11 +72,13 @@ RSpec.describe 'Carrier ADMIN role' do
     fill_in 'Name', with: 'Updated Name'
     fill_in 'Model', with: 'Updated Model'
     find('#carrier_current_location_id').find(:option, lancaster.name).select_option
+    select 'Sold', from: 'Status'
     click_on 'Update Carrier'
 
     expect(page).to have_content('Updated Name')
     expect(page).to have_content('Updated Model')
     expect(page).to have_content('Lancaster')
+    expect(page).to have_content('Sold')
   end
 
   scenario 'EDIT without any required fields' do
@@ -104,6 +106,7 @@ RSpec.describe 'Carrier ADMIN role' do
     fill_in 'Manufacturer', with: 'Test Manufacturer'
     fill_in 'Model', with: 'Test Model'
     fill_in 'Color', with: 'White'
+    select 'Unavailable', from: 'Status'
     find('#carrier_category_id').find(:option, category.name).select_option
 
     click_on 'Create Carrier'
@@ -139,6 +142,7 @@ RSpec.describe 'Carrier ADMIN role' do
     expect(page).to have_content('Manufacturer')
     expect(page).to have_content('Model')
     expect(page).to have_content('Color')
+    expect(page).to have_content('Status')
 
     expect(current_path).to eq '/carriers/new'
   end
@@ -176,6 +180,7 @@ RSpec.describe 'Carrier VOLUNTEER role' do
     expect(page).to have_content('test carrier')
     expect(page).to have_content('babywearing')
     expect(page).to have_content('test model')
+    expect(page).to have_content('Available')
   end
 
   scenario 'EDIT with all required fields' do

--- a/spec/fixtures/carriers.yml
+++ b/spec/fixtures/carriers.yml
@@ -8,3 +8,40 @@ carrier:
   size: 5
   home_location: washington
   current_location: lancaster
+  status: 'available'
+
+unavailable:
+  name: "unavailable carrier"
+  item_id: "TEST1235"
+  category: category_parent
+  manufacturer: "babywearing"
+  model: "test model"
+  color: "red"
+  size: 5
+  home_location: washington
+  current_location: lancaster
+  status: 'unavailable'
+
+sold:
+  name: "sold carrier"
+  item_id: "TEST1236"
+  category: category_parent
+  manufacturer: "babywearing"
+  model: "spec model"
+  color: "crimson"
+  size: 6
+  home_location: washington
+  current_location: lancaster
+  status: 'sold'
+
+disabled:
+  name: "disabled carrier"
+  item_id: "TEST1237"
+  category: category_parent
+  manufacturer: "babywearing"
+  model: "test model"
+  color: "purple"
+  size: 4
+  home_location: washington
+  current_location: lancaster
+  status: 'disabled'

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Carrier do
       color: 'blue',
       home_location_id: washington.id,
       current_location: lancaster,
-      category_id: category.id
+      category_id: category.id,
+      status: 'available'
     )).to be_valid
   end
 
@@ -51,6 +52,14 @@ RSpec.describe Carrier do
 
   it 'is not valid without a current_location_id' do
     expect(described_class.new(current_location_id: nil)).to_not be_valid
+  end
+
+  it 'is not valid without a status' do
+    expect(described_class.new(status: nil)).to_not be_valid
+  end
+
+  it 'is not valid with an unknown status' do
+    expect { described_class.new(status: 'lost') }.to raise_error(ArgumentError).with_message("'lost' is not a valid status")
   end
 
   describe '#build_loan' do

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -5,18 +5,11 @@ RSpec.describe Carrier do
   let(:lancaster) { locations(:lancaster) }
   let(:category) { categories(:category) }
 
-  it 'is valid with valid attributes' do
-    expect(described_class.new(
-      item_id: 1,
-      name: 'test name',
-      manufacturer: 'apple',
-      model: 'iCarry',
-      color: 'blue',
-      home_location_id: washington.id,
-      current_location: lancaster,
-      category_id: category.id,
-      status: 'available'
-    )).to be_valid
+  it 'has a valid fixture' do
+    expect(carriers(:carrier)).to be_valid
+    expect(carriers(:unavailable)).to be_valid
+    expect(carriers(:disabled)).to be_valid
+    expect(carriers(:sold)).to be_valid
   end
 
   it "should have a photo attached" do
@@ -52,14 +45,6 @@ RSpec.describe Carrier do
 
   it 'is not valid without a current_location_id' do
     expect(described_class.new(current_location_id: nil)).to_not be_valid
-  end
-
-  it 'is not valid without a status' do
-    expect(described_class.new(status: nil)).to_not be_valid
-  end
-
-  it 'is not valid with an unknown status' do
-    expect { described_class.new(status: 'lost') }.to raise_error(ArgumentError).with_message("'lost' is not a valid status")
   end
 
   describe '#available_for_checkout?' do

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe Carrier do
     expect { described_class.new(status: 'lost') }.to raise_error(ArgumentError).with_message("'lost' is not a valid status")
   end
 
+  describe '#available_for_checkout?' do
+    let(:carrier) { carriers(:carrier) }
+
+    it 'is an alias for available?' do
+      expect(carrier.available_for_checkout?).to eq carrier.available?
+    end
+  end
+
   describe '#build_loan' do
     let(:carrier) { described_class.first }
 


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #107

### Description

Adds an enum column to `Carrier` to indicate the status of that carrier within the system. Adds the ability to set and view that status through the standard crud screens.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Manually tested myself and updated the unit and features specs with new changes.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->
