### PR TITLE
FIX: Security hole and failing spec

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -12,7 +12,7 @@ en:
       invalid: "Invalid %{authentication_keys}/Password."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
+      not_found_in_database: "Invalid %{authentication_keys}/Password."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."

--- a/spec/features/visitor_signs_in_spec.rb
+++ b/spec/features/visitor_signs_in_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe 'Visitor signs in', type: :feature do
   scenario "with invalid email" do
     sign_in_with email: "invalid.email@exmaple.org", password: VALID_PASSWORD
     user_should_be_signed_out
-    expect(page).to have_content "Invalid Email or password."
+    expect(page).to have_content "Invalid Email/Password."
   end
 
   scenario "with invalid password" do
     sign_in_with email: user.email, password: "invalid_password"
     user_should_be_signed_out
-    expect(page).to have_content "Invalid Email or password."
+    expect(page).to have_content "Invalid Email/Password."
   end
 end


### PR DESCRIPTION
PR #176 introduced different message when login is not successful.
But not all Devise locales are changed so we had situation depending on
what is invalid `email` or `password` we will get different message.
Which exposes security risk, because someone can figure out valid email
more easily.

Also, because of that specs are failing. So I've fixed the local and
expected message in the specs.

