### PR TITLE
Add Safety Link

### DIFF
--- a/app/controllers/carriers_controller.rb
+++ b/app/controllers/carriers_controller.rb
@@ -75,6 +75,7 @@ class CarriersController < ApplicationController
       :model,
       :color,
       :size,
+      :safety_link,
       :home_location_id,
       :current_location_id,
       :category_id,

--- a/app/views/carriers/_carrier_form.html.erb
+++ b/app/views/carriers/_carrier_form.html.erb
@@ -30,6 +30,11 @@
   </div>
 
   <div class="form-group">
+    <%= form.label :safety_link, 'Safety Link' %>
+    <%= form.text_field :safety_link, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
     <%= form.label :home_location_id, 'Home Location' %>
     <%= form.collection_select :home_location_id, @locations, :id, :name, {}, class: "form-control" %>
   </div>

--- a/app/views/carriers/show.html.erb
+++ b/app/views/carriers/show.html.erb
@@ -10,6 +10,7 @@
   <li>Model: <%= @carrier.model %></li>
   <li>Color: <%= @carrier.color %></li>
   <li>Size: <%= @carrier.size %></li>
+  <li>Safety Link: <%=link_to "Safety Information",  @carrier.safety_link %></li>
   <li>Category: <%= @carrier.category.name %></li>
   <li>Home Location: <%= @carrier.home_location.name %></li>
   <li>Current Location: <%= @carrier.current_location.name %></li>

--- a/db/migrate/20191024165716_add_safety_link_to_carriers.rb
+++ b/db/migrate/20191024165716_add_safety_link_to_carriers.rb
@@ -1,0 +1,5 @@
+class AddSafetyLinkToCarriers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :carriers, :safety_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_053330) do
+ActiveRecord::Schema.define(version: 2019_10_24_165716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2019_10_16_053330) do
     t.integer "category_id"
     t.bigint "home_location_id", null: false
     t.bigint "current_location_id", null: false
+    t.string "safety_link"
     t.index ["current_location_id"], name: "index_carriers_on_current_location_id"
     t.index ["home_location_id"], name: "index_carriers_on_home_location_id"
   end

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'Carrier ADMIN role' do
     expect(page).to have_content('Manufacturer')
     expect(page).to have_content('Model')
     expect(page).to have_content('Color')
+    expect(page).to have_content('Safety Link')
 
     expect(current_path).to eq '/carriers/new'
   end


### PR DESCRIPTION

Resolves #170 

### Description
I added safety link to the carrier table.
I have added Safety Link to the entry page for a carrier:
![Babywearing](https://user-images.githubusercontent.com/10904005/67526905-bb000480-f683-11e9-8d47-93e3c4a814b8.jpg)

and I added it to the show page:
![Babywearing](https://user-images.githubusercontent.com/10904005/67526954-d23ef200-f683-11e9-906f-39fdbba44b79.jpg)

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
I added to the existing carrier spec.  This is not a required field.
