### PR TITLE
Enable rubocop on codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,7 @@
 version: "2" # required to adjust maintainability checks
+plugins:
+  rubocop:
+    enabled: true
 checks:
   argument-count:
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,7 @@ version: "2" # required to adjust maintainability checks
 plugins:
   rubocop:
     enabled: true
+    channel: rubocop-0-74
 checks:
   argument-count:
     config:


### PR DESCRIPTION
This is the first pass at enabling rubocop on code climate and will probably be followed by a few commits / PR's to get the commenting right.