### PR TITLE
Fix browse button for Firefox

### DIFF
--- a/app/views/carriers/_carrier_form.html.erb
+++ b/app/views/carriers/_carrier_form.html.erb
@@ -76,7 +76,7 @@
 
   <div class="form-group">
     <%= form.label :photos, class: "pl-1 mb-0" %>
-    <%= form.file_field :photos, multiple: true, class: "btn pl-1 form-control" %>
+    <%= form.file_field :photos, multiple: true, class: "btn pl-1" %>
   </div>
 
   <%= form.submit class: "btn btn-primary" %>


### PR DESCRIPTION
Resolves #211 

The browse button to add a photo to a carrier was cut off on the bottom.  Turns out it was only on Firefox.  Removing the styling on the button fixed it and actually improves the look in chrome as well.
Firefox:
![Babywearing](https://user-images.githubusercontent.com/10904005/68995381-2b510e80-085b-11ea-8484-517c300a8aae.jpg)

Chrome:
![Babywearing](https://user-images.githubusercontent.com/10904005/68995385-402da200-085b-11ea-9e07-45835fe7c905.jpg)

