### PR TITLE
Resolve 'to be removed' Rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,5 @@
 require: rubocop-rspec
 
-# TBR = to be removed and fixed
-
 AllCops:
   Exclude:
     - 'db/schema.rb'
@@ -15,17 +13,8 @@ AllCops:
 Rails:
   Enabled: true
 
-# TBR
-Style/IfUnlessModifier:
-  Enabled: false
-
-# TBR
-Style/GuardClause:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
-
 
 Style/EmptyMethod:
   Enabled: false
@@ -38,10 +27,6 @@ Metrics/MethodLength:
 
 Metrics/LineLength:
   Max: 120
-
-# TBR
-Style/StringLiterals:
-  Enabled: false
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -19,15 +19,15 @@ gem 'acts_as_tenant'
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.3.1'
-gem "bootstrap-table-rails"
+gem 'bootstrap-table-rails'
 gem 'filterrific'
-gem "font-awesome-rails"
+gem 'font-awesome-rails'
 gem 'jbuilder', '~> 2.10.0'
 gem 'jquery-rails'
 gem 'mini_magick', '~> 4.8'
 gem 'money-rails', '~>1.12'
 gem 'name_of_person'
-gem "responders"
+gem 'responders'
 gem 'turbolinks', '~> 5'
 gem 'whenever', require: false
 gem 'will_paginate'
@@ -38,8 +38,8 @@ group :development, :test do
 end
 
 group :development do
-  gem "better_errors"
-  gem "binding_of_caller"
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'pivotal_git_scripts'
   gem 'web-console', '>= 3.3.0'

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -41,9 +41,7 @@ class AgreementsController < ApplicationController
   def destroy
     authorize @agreement
 
-    if @agreement.destroy
-      redirect_to agreements_url, alert: 'Agreement was successfully destroyed.'
-    end
+    redirect_to agreements_url, alert: 'Agreement was successfully destroyed.' if @agreement.destroy
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "modal_responder"
+require 'modal_responder'
 
 class ApplicationController < ActionController::Base
   # set_current_tenant_by_subdomain(:organization, :subdomain)
@@ -54,8 +54,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_version
-    @version = ""
-    fn = File.join(Rails.root, "deploy", "deploy_hash")
+    @version = ''
+    fn = File.join(Rails.root, 'deploy', 'deploy_hash')
     return unless File.exist?(fn)
 
     @version = File.open(fn, &:gets).strip[0..5]

--- a/app/controllers/carriers/loans_controller.rb
+++ b/app/controllers/carriers/loans_controller.rb
@@ -38,9 +38,7 @@ module Carriers
 
     def update_loan
       merging = {}
-      if @loan.outstanding? && loan_params[:returned_on].present?
-        merging = { checkin_volunteer_id: current_user.id }
-      end
+      merging = { checkin_volunteer_id: current_user.id } if @loan.outstanding? && loan_params[:returned_on].present?
       @loan.update(loan_params.merge(merging))
     end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -49,9 +49,9 @@ class CategoriesController < ApplicationController
   def destroy
     authorize @category
 
-    if @category.destroy
-      redirect_to categories_url(subdomain: current_tenant.subdomain), alert: 'Category was successfully destroyed.'
-    end
+    return unless @category.destroy
+
+    redirect_to categories_url(subdomain: current_tenant.subdomain), alert: 'Category was successfully destroyed.'
   end
 
   private

--- a/app/controllers/fee_types_controller.rb
+++ b/app/controllers/fee_types_controller.rb
@@ -48,9 +48,7 @@ class FeeTypesController < ApplicationController
   def destroy
     authorize @fee_type
 
-    if @fee_type.destroy
-      redirect_to fee_types_url, alert: 'Fee type was successfully destroyed.'
-    end
+    redirect_to fee_types_url, alert: 'Fee type was successfully destroyed.' if @fee_type.destroy
   end
 
   private

--- a/app/controllers/membership_types_controller.rb
+++ b/app/controllers/membership_types_controller.rb
@@ -47,9 +47,7 @@ class MembershipTypesController < ApplicationController
   def destroy
     authorize @membership_type
 
-    if @membership_type.destroy
-      redirect_to membership_types_url, alert: 'Membership type was successfully destroyed.'
-    end
+    redirect_to membership_types_url, alert: 'Membership type was successfully destroyed.' if @membership_type.destroy
   end
 
   private

--- a/app/controllers/users/memberships_controller.rb
+++ b/app/controllers/users/memberships_controller.rb
@@ -9,7 +9,7 @@ module Users
     def create
       @membership = authorize @user.memberships.new(membership_params)
       if @membership.save
-        redirect_to user_path(@user), notice: "Membership successfully created."
+        redirect_to user_path(@user), notice: 'Membership successfully created.'
       else
         respond_modal_with @membership
       end
@@ -17,9 +17,7 @@ module Users
 
     def destroy
       @membership = authorize @user.memberships.find(params[:id])
-      if @membership.destroy
-        flash[:notice] = "Membership successfully removed."
-      end
+      flash[:notice] = 'Membership successfully removed.' if @membership.destroy
       redirect_to user_path(@user)
     end
 
@@ -37,7 +35,7 @@ module Users
     def update
       @membership = authorize @user.memberships.find(params[:id])
       if @membership.update(membership_params)
-        redirect_to user_path(@user), notice: "Membership successfully updated."
+        redirect_to user_path(@user), notice: 'Membership successfully updated.'
       else
         respond_modal_with @membership
       end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,10 +6,10 @@ module Users
 
     def create
       super
-      if resource.persisted?
-        set_flash_message!(:notice, current_user == resource ? :signed_up : :signed_up_by_user)
-        resource.send_welcome_email
-      end
+      return unless resource.persisted?
+
+      set_flash_message!(:notice, current_user == resource ? :signed_up : :signed_up_by_user)
+      resource.send_welcome_email
     end
 
     private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,10 +3,10 @@
 module ApplicationHelper
   def flash_class(level)
     case level.to_sym
-    when :notice then "alert alert-info"
-    when :success then "alert alert-success"
-    when :error then "alert alert-error"
-    when :alert then "alert alert-error"
+    when :notice then 'alert alert-info'
+    when :success then 'alert alert-success'
+    when :error then 'alert alert-error'
+    when :alert then 'alert alert-error'
     end
   end
 

--- a/app/helpers/carriers_helper.rb
+++ b/app/helpers/carriers_helper.rb
@@ -3,13 +3,13 @@
 module CarriersHelper
   def carrier_badge_class(carrier)
     if carrier.available?
-      "badge badge-success"
+      'badge badge-success'
     else
-      "badge badge-danger"
+      'badge badge-danger'
     end
   end
 
   def carrier_editable_states_for_select
-    Carrier.aasm.states_for_select.reject { |s| s.first == "Checked out" }
+    Carrier.aasm.states_for_select.reject { |s| s.first == 'Checked out' }
   end
 end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -8,6 +8,6 @@ module FormsHelper
   #   <%= form_errors @record %>
   #
   def form_errors(model)
-    render "shared/form_errors", model: model
+    render 'shared/form_errors', model: model
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -10,11 +10,11 @@ module UsersHelper
   end
 
   def membership_status(user)
-    return "No Membership" if user.memberships.empty?
+    return 'No Membership' if user.memberships.empty?
 
     current = user.current_membership
-    return "Expired" unless current.present?
+    return 'Expired' unless current.present?
 
-    current.blocked? ? "Blocked" : "Current"
+    current.blocked? ? 'Blocked' : 'Current'
   end
 end

--- a/app/models/carrier/filter_impl.rb
+++ b/app/models/carrier/filter_impl.rb
@@ -5,12 +5,12 @@ class Carrier
     extend ActiveSupport::Concern
 
     included do
-      scope :search_manufacturer, ->(query) { where("manufacturer ilike ?", "%#{query}%") }
-      scope :search_item_id, ->(query) { where("item_id ilike ?", "%#{query}%") }
-      scope :search_model, ->(query) { where("model ilike ?", "%#{query}%") }
-      scope :search_name, ->(query) { where("name ilike ?", "%#{query}%") }
-      scope :with_category_id, ->(category_id) { where("category_id = ?", category_id) }
-      scope :with_current_location_id, ->(current_location_id) { where("current_location_id = ?", current_location_id) }
+      scope :search_manufacturer, ->(query) { where('manufacturer ilike ?', "%#{query}%") }
+      scope :search_item_id, ->(query) { where('item_id ilike ?', "%#{query}%") }
+      scope :search_model, ->(query) { where('model ilike ?', "%#{query}%") }
+      scope :search_name, ->(query) { where('name ilike ?', "%#{query}%") }
+      scope :with_category_id, ->(category_id) { where('category_id = ?', category_id) }
+      scope :with_current_location_id, ->(current_location_id) { where('current_location_id = ?', current_location_id) }
       scope :with_state_in, ->(state) { where(state: state) }
 
       filterrific(available_filters: %i[

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,8 +4,8 @@ class Category < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   has_many :carriers
-  has_many :subcategories, class_name: "Category",
-                           foreign_key: "parent_id"
+  has_many :subcategories, class_name: 'Category',
+                           foreign_key: 'parent_id'
 
-  belongs_to :parent, class_name: "Category", optional: true
+  belongs_to :parent, class_name: 'Category', optional: true
 end

--- a/app/models/fee_type.rb
+++ b/app/models/fee_type.rb
@@ -5,5 +5,5 @@ class FeeType < ApplicationRecord
 
   validates_presence_of :name, :fee_cents
 
-  monetize :fee_cents, as: "fee"
+  monetize :fee_cents, as: 'fee'
 end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -4,7 +4,7 @@ class Loan < ApplicationRecord
   include Loan::FilterImpl
 
   belongs_to :carrier
-  belongs_to :borrower, class_name: "User", optional: true, inverse_of: :loans # see presence validation below
+  belongs_to :borrower, class_name: 'User', optional: true, inverse_of: :loans # see presence validation below
   belongs_to :checkout_volunteer, class_name: 'User', default: -> { Current.user }
   belongs_to :checkin_volunteer, class_name: 'User', optional: true
 
@@ -14,7 +14,7 @@ class Loan < ApplicationRecord
   scope :due_in_one_week, -> { where(due_date: (Time.zone.today + 1.week)) }
 
   validates :carrier, :due_date, presence: true
-  validates :borrower, presence: { message: "must be selected" }
+  validates :borrower, presence: { message: 'must be selected' }
   after_create :checkout_carrier
   after_save :checkin_carrier
 
@@ -31,9 +31,7 @@ class Loan < ApplicationRecord
   private
 
   def checkin_carrier
-    if returned_on.present? && carrier.checked_out?
-      carrier.checkin!
-    end
+    carrier.checkin! if returned_on.present? && carrier.checked_out?
   end
 
   def checkout_carrier

--- a/app/models/loan/filter_impl.rb
+++ b/app/models/loan/filter_impl.rb
@@ -5,9 +5,9 @@ class Loan
     extend ActiveSupport::Concern
 
     included do
-      scope :search_carrier, ->(query) { joins(:carrier).where("carriers.model ilike ?", "%#{query}%") }
-      scope :with_due_date_before, ->(date) { where("due_date <= ?", "%#{date}%") }
-      scope :with_due_date_after, ->(date) { where("due_date >= ?", "%#{date}%") }
+      scope :search_carrier, ->(query) { joins(:carrier).where('carriers.model ilike ?', "%#{query}%") }
+      scope :with_due_date_before, ->(date) { where('due_date <= ?', "%#{date}%") }
+      scope :with_due_date_after, ->(date) { where('due_date >= ?', "%#{date}%") }
       scope :with_borrower_id, ->(user_id) { where(borrower_id: user_id) }
       scope :with_checkout_volunteer_id, ->(user_id) { where(checkout_volunteer_id: user_id) }
       scope :with_checkin_volunteer_id, ->(user_id) { where(checkin_volunteer_id: user_id) }
@@ -22,9 +22,9 @@ class Loan
 
       scope :with_overdue, lambda { |yes_or_no|
         if yes_or_no == 'Yes'
-          where("returned_on IS NULL AND due_date < ?", Time.zone.today)
+          where('returned_on IS NULL AND due_date < ?', Time.zone.today)
         elsif yes_or_no == 'No'
-          where("returned_on IS NOT NULL OR due_date >= ?", Time.zone.today)
+          where('returned_on IS NOT NULL OR due_date >= ?', Time.zone.today)
         end
       }
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -26,6 +26,6 @@ class Membership < ApplicationRecord
     return if expiration.nil? || effective.nil?
     return if expiration >= effective
 
-    errors.add(:expiration, "cannot be before effective date")
+    errors.add(:expiration, 'cannot be before effective date')
   end
 end

--- a/app/models/membership_type.rb
+++ b/app/models/membership_type.rb
@@ -3,7 +3,7 @@
 class MembershipType < ApplicationRecord
   acts_as_tenant(:organization)
 
-  monetize :fee_cents, as: "fee"
+  monetize :fee_cents, as: 'fee'
 
   validates :name, :short_name, :fee_cents, :duration_days, :number_of_items, presence: true
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,9 +9,9 @@ class Organization < ApplicationRecord
   has_many :locations
   has_many :users
 
-  scope :nonadmin, -> { where.not("subdomain = ?", 'admin') }
+  scope :nonadmin, -> { where.not('subdomain = ?', 'admin') }
 
   def admin?
-    subdomain == "admin"
+    subdomain == 'admin'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
 
   has_many :signed_agreements
   has_many :carts
-  has_many :loans, foreign_key: "borrower_id"
+  has_many :loans, foreign_key: 'borrower_id'
   has_many :memberships
 
   enum role: %i[admin volunteer member]
@@ -51,7 +51,7 @@ class User < ApplicationRecord
 
   def current_membership
     today = Time.zone.today
-    membership = memberships.where("expiration > ? AND effective <= ?", today, today).order(expiration: :desc).first
+    membership = memberships.where('expiration > ? AND effective <= ?', today, today).order(expiration: :desc).first
     return if membership.nil?
 
     membership
@@ -66,9 +66,7 @@ class User < ApplicationRecord
     return name.full if membership.nil?
 
     s = "#{name.full} - #{membership.membership_type.short_name}"
-    if membership.expired?
-      s += " (Expired)"
-    end
+    s += ' (Expired)' if membership.expired?
     s
   end
 

--- a/app/validators/subdomain_validator.rb
+++ b/app/validators/subdomain_validator.rb
@@ -7,9 +7,8 @@ class SubdomainValidator < ActiveModel::EachValidator
 
     reserved_names = %w[www ftp mail pop smtp ssl sftp]
     reserved_names = options[:reserved] if options[:reserved]
-    if reserved_names.include?(value)
-      object.errors[attribute] << 'cannot be a reserved name'
-    end
+    object.errors[attribute] << 'cannot be a reserved name' if reserved_names.include?(value)
+
     check_length(object, attribute, value)
     check_start(object, attribute, value)
     check_alphanumeric(object, attribute, value)

--- a/app/views/categories/index.json.jbuilder
+++ b/app/views/categories/index.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.array! @categories, partial: "categories/category", as: :category
+json.array! @categories, partial: 'categories/category', as: :category

--- a/app/views/categories/show.json.jbuilder
+++ b/app/views/categories/show.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.partial! "categories/category", category: @category
+json.partial! 'categories/category', category: @category

--- a/app/views/fee_types/index.json.jbuilder
+++ b/app/views/fee_types/index.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.array! @fee_types, partial: "fee_types/fee_type", as: :fee_type
+json.array! @fee_types, partial: 'fee_types/fee_type', as: :fee_type

--- a/app/views/fee_types/show.json.jbuilder
+++ b/app/views/fee_types/show.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.partial! "fee_types/fee_type", fee_type: @fee_type
+json.partial! 'fee_types/fee_type', fee_type: @fee_type

--- a/app/views/membership_types/index.json.jbuilder
+++ b/app/views/membership_types/index.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.array! @membership_types, partial: "membership_types/membership_type", as: :membership_type
+json.array! @membership_types, partial: 'membership_types/membership_type', as: :membership_type

--- a/app/views/membership_types/show.json.jbuilder
+++ b/app/views/membership_types/show.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.partial! "membership_types/membership_type", membership_type: @membership_type
+json.partial! 'membership_types/membership_type', membership_type: @membership_type

--- a/lib/tasks/reminder_email.rake
+++ b/lib/tasks/reminder_email.rake
@@ -13,21 +13,21 @@ end
 # frozen_string_literal: true
 
 namespace :mail do
-  desc "Send email that carrier is due today"
+  desc 'Send email that carrier is due today'
   task due_today_reminder: :environment do
     Loan.due_today.find_each do |loan|
       ReminderMailer.with(mailer_parameters(loan)).due_today_email.deliver_now
     end
   end
 
-  desc "Send email that carrier is due in one week"
+  desc 'Send email that carrier is due in one week'
   task week_advance_reminder: :environment do
     Loan.due_in_one_week.find_each do |loan|
       ReminderMailer.with(mailer_parameters(loan)).week_advance_notice_email.deliver_now
     end
   end
 
-  desc "Send email that carrier is overdue"
+  desc 'Send email that carrier is overdue'
   task overdue_reminder: :environment do
     Loan.overdue.find_each do |loan|
       ReminderMailer.with(mailer_parameters(loan)).overdue_email.deliver_now

--- a/spec/features/agreement_spec.rb
+++ b/spec/features/agreement_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'create an agreement', type: :feature do
   let(:agreement) { agreements(:agreement) }
 
   before do
-    visit "/"
+    visit '/'
     sign_in user
   end
 

--- a/spec/features/carrier_spec.rb
+++ b/spec/features/carrier_spec.rb
@@ -293,28 +293,28 @@ RSpec.describe Carrier do
     end
   end
 
-  describe "view mode" do
+  describe 'view mode' do
     before do
       sign_in user
       visit carriers_url
     end
 
-    it "can set the view mode to list" do
-      click_on(class: "carrier-list-link")
+    it 'can set the view mode to list' do
+      click_on(class: 'carrier-list-link')
 
-      expect(page).to have_current_path(carriers_url(view: "list"))
+      expect(page).to have_current_path(carriers_url(view: 'list'))
       expect(page).to have_css('table')
     end
 
-    it "can set the view mode to icon" do
-      click_on(class: "carrier-icon-link")
+    it 'can set the view mode to icon' do
+      click_on(class: 'carrier-icon-link')
 
-      expect(page).to have_current_path(carriers_url(view: "icon"))
+      expect(page).to have_current_path(carriers_url(view: 'icon'))
       expect(page).not_to have_css('table')
     end
 
-    it "uses view mode from cookie" do
-      Capybara.current_session.driver.browser.set_cookie("carrier_view=list")
+    it 'uses view mode from cookie' do
+      Capybara.current_session.driver.browser.set_cookie('carrier_view=list')
       visit carriers_url
       expect(page).to have_css('table')
     end

--- a/spec/features/carriers/loans_spec.rb
+++ b/spec/features/carriers/loans_spec.rb
@@ -16,29 +16,29 @@ RSpec.feature 'Loan spec', type: :feature do
     sign_in admin
     visit carrier_url(carrier)
 
-    click_link "Checkout"
-    select borrower.name, from: "loan_borrower_id"
-    click_on "Checkout"
+    click_link 'Checkout'
+    select borrower.name, from: 'loan_borrower_id'
+    click_on 'Checkout'
 
     expect(page).to have_current_path(carrier_path(carrier))
-    expect(page).to have_content("Checked Out")
+    expect(page).to have_content('Checked Out')
   end
 
   scenario 'Volunteer can create a new checkout' do
     sign_in volunteer
     visit carrier_url(carrier)
 
-    click_link "Checkout"
-    select borrower.name, from: "loan_borrower_id"
-    click_on "Checkout"
+    click_link 'Checkout'
+    select borrower.name, from: 'loan_borrower_id'
+    click_on 'Checkout'
 
     expect(page).to have_current_path(carrier_path(carrier))
-    expect(page).to have_content("Checked Out")
+    expect(page).to have_content('Checked Out')
   end
 
   scenario 'User is not able to perform checkout if carrier is not available' do
     sign_in admin
     visit carrier_url(carriers(:unavailable))
-    expect(page).not_to have_selector(:link_or_button, "Checkout")
+    expect(page).not_to have_selector(:link_or_button, 'Checkout')
   end
 end

--- a/spec/features/category_spec.rb
+++ b/spec/features/category_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "category" do
+RSpec.feature 'category' do
   let!(:category) { categories(:category_parent) }
   let!(:category_child) { categories(:category) }
   let(:user) { users(:admin_org) }
@@ -10,37 +10,37 @@ RSpec.feature "category" do
     sign_in user
   end
 
-  it "allows user to create a category" do
-    visit categories_url(subdomain: "admin")
-    find_link("+ New").click
-    fill_in "Name", with: "pineapple"
-    fill_in "Description", with: "sweet"
-    fill_in "Parent", with: "1"
-    click_button "Create Category"
+  it 'allows user to create a category' do
+    visit categories_url(subdomain: 'admin')
+    find_link('+ New').click
+    fill_in 'Name', with: 'pineapple'
+    fill_in 'Description', with: 'sweet'
+    fill_in 'Parent', with: '1'
+    click_button 'Create Category'
 
-    expect(page).to have_content "Category was successfully created."
+    expect(page).to have_content 'Category was successfully created.'
   end
 
-  it "allows user to update a category" do
-    visit categories_url(subdomain: "admin")
+  it 'allows user to update a category' do
+    visit categories_url(subdomain: 'admin')
     click_link category.name
     expect(page).to have_content category.name
-    find_link("Edit").click
-    fill_in "Name", with: "orange"
-    click_button "Update Category"
-    expect(page).to have_content "Category was successfully updated."
-    expect(page).to have_content "orange"
+    find_link('Edit').click
+    fill_in 'Name', with: 'orange'
+    click_button 'Update Category'
+    expect(page).to have_content 'Category was successfully updated.'
+    expect(page).to have_content 'orange'
   end
 
-  it "allows user to delete a category" do
-    visit categories_url(subdomain: "admin")
+  it 'allows user to delete a category' do
+    visit categories_url(subdomain: 'admin')
     expect(page).to have_content category.name
-    find_link("Destroy").click
-    expect(page).to have_content "Category was successfully destroyed."
+    find_link('Destroy').click
+    expect(page).to have_content 'Category was successfully destroyed.'
   end
 
   it 'expands the subcategories table' do
-    visit(categories_url(subdomain: "admin"))
+    visit(categories_url(subdomain: 'admin'))
     expect(page).to have_content(category.name)
     expect(page).not_to have_content(category_child.name)
     find_link('+').click

--- a/spec/features/fee_type_spec.rb
+++ b/spec/features/fee_type_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.feature "fee_type" do
+RSpec.feature 'fee_type' do
   let(:user) { users(:admin) }
   let(:fee_type) { fee_types(:upgrade) }
 
   before do
-    visit "/"
+    visit '/'
     sign_in user
   end
 
@@ -14,7 +14,7 @@ RSpec.feature "fee_type" do
     click_link fee_type.name
 
     expect(page).to have_content(fee_type.name)
-    expect(page).to have_content("20.00")
+    expect(page).to have_content('20.00')
   end
 
   scenario 'EDIT when name is NOT given' do

--- a/spec/features/location_spec.rb
+++ b/spec/features/location_spec.rb
@@ -7,37 +7,37 @@ RSpec.describe Location, type: :feature do
   # you can't do these things to a location
 
   before do
-    visit "/"
+    visit '/'
     sign_in user
   end
 
   it 'allows admin to CREATE new locations' do
     visit locations_url
-    find_link("+ New", match: :first).click
-    fill_in "Name", with: "Bellvue"
-    click_button "Create Location"
-    expect(page).to have_content "Bellvue"
+    find_link('+ New', match: :first).click
+    fill_in 'Name', with: 'Bellvue'
+    click_button 'Create Location'
+    expect(page).to have_content 'Bellvue'
   end
 
   it 'allows admin to UPDATE a location' do
     visit locations_url
-    find_link("+ New", match: :first).click
-    fill_in "Name", with: "Robinson"
-    click_button "Create Location"
-    expect(page).to have_content "Robinson"
-    find_link("Edit this location").click
-    fill_in "Name", with: "New location"
-    click_button "Update Location"
-    expect(page).to have_content "New location"
+    find_link('+ New', match: :first).click
+    fill_in 'Name', with: 'Robinson'
+    click_button 'Create Location'
+    expect(page).to have_content 'Robinson'
+    find_link('Edit this location').click
+    fill_in 'Name', with: 'New location'
+    click_button 'Update Location'
+    expect(page).to have_content 'New location'
   end
 
   it 'allows admin to DELETE a location' do
     visit locations_url
-    find_link("+ New", match: :first).click
-    fill_in "Name", with: "Bridgeville"
-    click_button "Create Location"
-    expect(page).to have_content "Bridgeville"
-    find_link("Delete this location").click
-    expect(page).not_to have_content "Location was successfully deleted."
+    find_link('+ New', match: :first).click
+    fill_in 'Name', with: 'Bridgeville'
+    click_button 'Create Location'
+    expect(page).to have_content 'Bridgeville'
+    find_link('Delete this location').click
+    expect(page).not_to have_content 'Location was successfully deleted.'
   end
 end

--- a/spec/features/membership_type_spec.rb
+++ b/spec/features/membership_type_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe 'MembershipType', type: :feature do
   let(:membership_type) { membership_types(:annual) }
 
   before do
-    visit "/"
+    visit '/'
     sign_in user
   end
 
   scenario 'EDIT when name is NOT given' do
     visit edit_membership_type_url(membership_type)
 
-    fill_in 'Name', with: ""
+    fill_in 'Name', with: ''
     click_on 'Update Membership type'
 
     expect(page).to have_content("Name can't be blank")
@@ -32,7 +32,7 @@ RSpec.describe 'MembershipType', type: :feature do
   scenario 'CREATE when name is NOT given' do
     visit membership_types_url
     click_link('+ New')
-    fill_in 'Name', with: ""
+    fill_in 'Name', with: ''
     click_on 'Create Membership type'
     expect(page).to have_content("Name can't be blank")
   end

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-RSpec.feature "user registration" do
-  it "allows user to create a user account" do
+RSpec.feature 'user registration' do
+  it 'allows user to create a user account' do
     visit root_url
-    find_link("Sign Up", match: :first).click
-    fill_in "Enter email address", with: "alicia@gmail.com"
-    fill_in "Password", with: "just4now"
-    fill_in "Confirm Password", with: "just4now"
-    fill_in "First name", with: "me"
-    fill_in "Last name", with: "last"
-    fill_in "Street address", with: "123 main street"
-    fill_in "City", with: "fairfax"
-    fill_in "State", with: "VA"
-    fill_in "Postal code", with: "22032"
-    fill_in "Phone", with: "8008885555"
-    click_button "Sign Up"
-    expect(page).to have_content("Welcome! You have signed up successfully.", count: 1)
+    find_link('Sign Up', match: :first).click
+    fill_in 'Enter email address', with: 'alicia@gmail.com'
+    fill_in 'Password', with: 'just4now'
+    fill_in 'Confirm Password', with: 'just4now'
+    fill_in 'First name', with: 'me'
+    fill_in 'Last name', with: 'last'
+    fill_in 'Street address', with: '123 main street'
+    fill_in 'City', with: 'fairfax'
+    fill_in 'State', with: 'VA'
+    fill_in 'Postal code', with: '22032'
+    fill_in 'Phone', with: '8008885555'
+    click_button 'Sign Up'
+    expect(page).to have_content('Welcome! You have signed up successfully.', count: 1)
   end
 
-  context "when the email is invalid" do
-    it "does not allow user to create a user account" do
+  context 'when the email is invalid' do
+    it 'does not allow user to create a user account' do
       visit root_url
-      find_link("Sign Up", match: :first).click
-      fill_in "Enter email address", with: "alicia.email.com"
-      fill_in "Password", with: "just4now"
-      fill_in "Confirm Password", with: "just4now"
-      click_button "Sign Up"
-      expect(page).to have_content "Email is invalid"
+      find_link('Sign Up', match: :first).click
+      fill_in 'Enter email address', with: 'alicia.email.com'
+      fill_in 'Password', with: 'just4now'
+      fill_in 'Confirm Password', with: 'just4now'
+      click_button 'Sign Up'
+      expect(page).to have_content 'Email is invalid'
     end
   end
 end

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'User signs out', type: :feature do
-  scenario "signs out" do
+  scenario 'signs out' do
     user = users(:member)
     sign_in user
     visit root_url

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -8,48 +8,48 @@ RSpec.describe User do
   let(:member) { users(:member) }
   let(:borrower) { users(:borrower) }
 
-  scenario "should allow a volunteer user to create another user" do
+  scenario 'should allow a volunteer user to create another user' do
     sign_in volunteer
 
     visit new_user_registration_url
     expect(page).to have_content 'Create New Member'
 
-    fill_in "Enter email address", with: "alicia@gmail.com"
-    fill_in "Password", with: "just4now"
-    fill_in "Confirm Password", with: "just4now"
-    fill_in "First name", with: "me"
-    fill_in "Last name", with: "last"
-    fill_in "Street address", with: "123 main street"
-    fill_in "City", with: "fairfax"
-    fill_in "State", with: "VA"
-    fill_in "Postal code", with: "22032"
-    fill_in "Phone", with: "8008885555"
-    click_button "Create New Member"
-    expect(page).to have_content("New member created successfully.", count: 1)
+    fill_in 'Enter email address', with: 'alicia@gmail.com'
+    fill_in 'Password', with: 'just4now'
+    fill_in 'Confirm Password', with: 'just4now'
+    fill_in 'First name', with: 'me'
+    fill_in 'Last name', with: 'last'
+    fill_in 'Street address', with: '123 main street'
+    fill_in 'City', with: 'fairfax'
+    fill_in 'State', with: 'VA'
+    fill_in 'Postal code', with: '22032'
+    fill_in 'Phone', with: '8008885555'
+    click_button 'Create New Member'
+    expect(page).to have_content('New member created successfully.', count: 1)
     expect(page).to have_content("Logged in as #{volunteer.email}")
   end
 
-  scenario "should allow user who is an admin to see list of users" do
+  scenario 'should allow user who is an admin to see list of users' do
     sign_in admin
     visit root_url
     click_on 'VIEW MEMBERS'
     expect(page).to have_content 'Members'
   end
 
-  scenario "should allow user who is a volunteer to see list of users" do
+  scenario 'should allow user who is a volunteer to see list of users' do
     sign_in volunteer
     visit root_url
     click_on 'VIEW MEMBERS'
-    expect(page).to have_content "Members"
+    expect(page).to have_content 'Members'
   end
 
-  scenario "should not allow a member to see a list of users" do
+  scenario 'should not allow a member to see a list of users' do
     sign_in member
     visit users_url
     expect(page).not_to have_content 'Members'
   end
 
-  scenario "should allow user who is an admin to export list of users" do
+  scenario 'should allow user who is an admin to export list of users' do
     sign_in admin
 
     visit users_url
@@ -59,7 +59,7 @@ RSpec.describe User do
     expect(header).to match "attachment; filename=\"users-#{Date.today}.csv\""
   end
 
-  scenario "should allow user who is a volunteer to export list of users" do
+  scenario 'should allow user who is a volunteer to export list of users' do
     sign_in volunteer
 
     visit users_url
@@ -69,32 +69,32 @@ RSpec.describe User do
     expect(header).to match "attachment; filename=\"users-#{Date.today}.csv\""
   end
 
-  scenario "user should be able to log out" do
+  scenario 'user should be able to log out' do
     sign_in member
 
     visit root_url
     find('.user-dropdown').click
-    click_on "Logout"
+    click_on 'Logout'
 
-    expect(page).to have_content "Log In"
+    expect(page).to have_content 'Log In'
   end
 
   scenario 'should allow user who is an admin to see members tile on header' do
     sign_in admin
     visit root_url
-    expect(page).to have_content "VIEW MEMBERS"
+    expect(page).to have_content 'VIEW MEMBERS'
   end
 
   scenario 'should allow user who is a volunteer to see members tile on header' do
     sign_in volunteer
     visit root_url
-    expect(page).to have_content "VIEW MEMBERS"
+    expect(page).to have_content 'VIEW MEMBERS'
   end
 
   scenario 'should not allow user who is a member to see members tile on header' do
     sign_in member
     visit root_url
-    expect(page).not_to have_content "VIEW MEMBERS"
+    expect(page).not_to have_content 'VIEW MEMBERS'
   end
 
   scenario 'should allow an admin to see User information page with loan history' do

--- a/spec/features/user_update_infos_spec.rb
+++ b/spec/features/user_update_infos_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'User update information', type: :feature do
     fill_in('Current password', with: 'password')
     fill_in('First name', with: 'New first name')
     fill_in('Last name', with: 'New last name')
-    click_button("Update")
+    click_button('Update')
     expect(page).to have_content('Your account has been updated successfully.')
     visit(edit_user_registration_url)
     expect(page).to have_field('First name', with: 'New first name')
@@ -34,7 +34,7 @@ RSpec.describe 'User update information', type: :feature do
     fill_in('Current password', with: '')
     fill_in('First name', with: 'New first name')
     fill_in('Last name', with: 'New last name')
-    click_button("Update")
+    click_button('Update')
     expect(page).to have_content("Current password can't be blank")
   end
 end

--- a/spec/features/visitor_signs_in_spec.rb
+++ b/spec/features/visitor_signs_in_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe 'Visitor signs in', type: :feature do
   let(:user) { users(:member) }
   let(:valid_password) { 'password' }
 
-  scenario "with valid email and password" do
+  scenario 'with valid email and password' do
     sign_in_with email: user.email, password: valid_password
     user_should_be_signed_in
   end
 
-  scenario "with invalid email" do
-    sign_in_with email: "invalid.email@exmaple.org", password: valid_password
+  scenario 'with invalid email' do
+    sign_in_with email: 'invalid.email@exmaple.org', password: valid_password
     user_should_be_signed_out
-    expect(page).to have_content "Invalid Email, Organization/Password."
+    expect(page).to have_content 'Invalid Email, Organization/Password.'
   end
 
-  scenario "with invalid password" do
-    sign_in_with email: user.email, password: "invalid_password"
+  scenario 'with invalid password' do
+    sign_in_with email: user.email, password: 'invalid_password'
     user_should_be_signed_out
-    expect(page).to have_content "Invalid Email, Organization/Password."
+    expect(page).to have_content 'Invalid Email, Organization/Password.'
   end
 end

--- a/spec/helpers/carriers_helper_spec.rb
+++ b/spec/helpers/carriers_helper_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe CarriersHelper do
-  describe "#carrier_badge_class" do
-    it "returns correct css class base on the carrier status" do
-      expect(helper.carrier_badge_class(carriers(:carrier))).to eq "badge badge-success"
-      expect(helper.carrier_badge_class(carriers(:unavailable))).to eq "badge badge-danger"
+  describe '#carrier_badge_class' do
+    it 'returns correct css class base on the carrier status' do
+      expect(helper.carrier_badge_class(carriers(:carrier))).to eq 'badge badge-success'
+      expect(helper.carrier_badge_class(carriers(:unavailable))).to eq 'badge badge-danger'
     end
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -6,42 +6,42 @@ RSpec.describe UsersHelper do
   let(:expired) { users(:expired) }
   let(:blocked) { users(:blocked) }
 
-  describe "#user_roles_select" do
-    it "returns user roles formated for rails select" do
+  describe '#user_roles_select' do
+    it 'returns user roles formated for rails select' do
       result = helper.user_roles_select
       expect(result).to eq [%w[Admin admin], %w[Volunteer volunteer], %w[Member member]]
     end
   end
 
-  describe "#membership_status" do
-    context "with no membership" do
+  describe '#membership_status' do
+    context 'with no membership' do
       it 'is none' do
         expect(helper.membership_status(nonmember)).to eq('No Membership')
       end
     end
 
-    context "with an expired membership" do
-      it "is expired" do
-        expect(helper.membership_status(expired)).to eq("Expired")
+    context 'with an expired membership' do
+      it 'is expired' do
+        expect(helper.membership_status(expired)).to eq('Expired')
       end
 
-      it "is not expired when there is also a current one" do
+      it 'is not expired when there is also a current one' do
         expired.memberships.create(membership_type_id: membership_types(:annual).id, effective: Time.zone.today - 1.day,
                                    expiration: Time.zone.today + 1.year)
 
-        expect(helper.membership_status(expired)).to eq("Current")
+        expect(helper.membership_status(expired)).to eq('Current')
       end
     end
 
-    context "with only a current membership" do
-      it "is current" do
-        expect(helper.membership_status(member)).to eq("Current")
+    context 'with only a current membership' do
+      it 'is current' do
+        expect(helper.membership_status(member)).to eq('Current')
       end
     end
 
-    context "with a blocked current membership" do
-      it "is blocked" do
-        expect(helper.membership_status(blocked)).to eq("Blocked")
+    context 'with a blocked current membership' do
+      it 'is blocked' do
+        expect(helper.membership_status(blocked)).to eq('Blocked')
       end
     end
   end

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Agreement do
   let(:user) { users(:user) }
   let(:agreement) { agreements(:agreement) }
 
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:organization) }
   end
 

--- a/spec/models/carrier/filter_impl_spec.rb
+++ b/spec/models/carrier/filter_impl_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Carrier::FilterImpl do
-  describe ".with_state_in" do
-    context "with parameter available" do
-      it "returns all and only ones with available state" do
+  describe '.with_state_in' do
+    context 'with parameter available' do
+      it 'returns all and only ones with available state' do
         carrier = carriers(:carrier)
         avail = carriers(:available)
         carriers = Carrier.with_state_in([:available])

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Carrier do
   let(:lancaster) { locations(:lancaster) }
   let(:category) { categories(:category) }
 
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:organization) }
   end
 
@@ -16,7 +16,7 @@ RSpec.describe Carrier do
     expect(carriers(:sold)).to be_valid
   end
 
-  it "has a photo attached" do
+  it 'has a photo attached' do
     carrier = described_class.new
     file = Rails.root.join('public', 'apple-touch-icon.png')
     carrier.photos.attach(io: File.open(file), filename: 'apple-touch-icon.png')
@@ -54,7 +54,7 @@ RSpec.describe Carrier do
   describe '#build_loan' do
     let(:carrier) { described_class.first }
 
-    context "without parameters" do
+    context 'without parameters' do
       subject(:loan) { carrier.build_loan }
 
       it 'creates a loan with the default due date set' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe Category, type: :model do
   let!(:category) { categories(:category) }
 
-  it "is unique" do
+  it 'is unique' do
     duplicate = described_class.new(name: category.name)
     duplicate.save
-    expect(duplicate.errors[:name]).to include "has already been taken"
+    expect(duplicate.errors[:name]).to include 'has already been taken'
   end
 end

--- a/spec/models/loan/filter_impl_spec.rb
+++ b/spec/models/loan/filter_impl_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Loan::FilterImpl do
-  describe ".with_overdue" do
+  describe '.with_overdue' do
     describe '.with_Yes' do
-      it "returns all overdue loans" do
+      it 'returns all overdue loans' do
         overdues = Loan.with_overdue('Yes')
 
         expect(overdues).to match_array([loans(:overdue_1), loans(:overdue_2)])
@@ -11,7 +11,7 @@ RSpec.describe Loan::FilterImpl do
     end
 
     describe '.with_No' do
-      it "returns all not overdue loans" do
+      it 'returns all not overdue loans' do
         not_overdues = Loan.with_overdue('No')
 
         expect(not_overdues).to match_array([loans(:outstanding), loans(:returned)])
@@ -19,7 +19,7 @@ RSpec.describe Loan::FilterImpl do
     end
 
     describe '.with_Any' do
-      it "returns all loans" do
+      it 'returns all loans' do
         all_loans = Loan.with_overdue('Any')
 
         expect(all_loans).to match_array(Loan.all)
@@ -27,15 +27,15 @@ RSpec.describe Loan::FilterImpl do
     end
   end
 
-  describe ".with_outstanding" do
-    context "with parameter available" do
-      it "returns all and only outstanding loans" do
+  describe '.with_outstanding' do
+    context 'with parameter available' do
+      it 'returns all and only outstanding loans' do
         loans = Loan.with_outstanding('Yes')
 
         expect(loans).to match_array([loans(:outstanding), loans(:overdue_1), loans(:overdue_2)])
       end
 
-      it "returns all and returned loans" do
+      it 'returns all and returned loans' do
         returned = loans(:returned)
         loans = Loan.with_outstanding('No')
 

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Loan do
   let(:carrier) { carriers(:carrier) }
 
   describe '#valid?' do
-    context "with a borrower, a checkout volunteer, a carrier, and a due date" do
+    context 'with a borrower, a checkout volunteer, a carrier, and a due date' do
       subject do
         described_class.new(
           carrier: carrier,
@@ -24,7 +24,7 @@ RSpec.describe Loan do
   end
 
   describe 'create' do
-    it "sets the due date to the date specified" do
+    it 'sets the due date to the date specified' do
       due_date = 20.days.from_now.utc.to_date
       loan = described_class.create(
         carrier: carrier,
@@ -37,8 +37,8 @@ RSpec.describe Loan do
     end
   end
 
-  context "without due date" do
-    it "sets the due date to be the default number of days away" do
+  context 'without due date' do
+    it 'sets the due date to be the default number of days away' do
       freeze_time do
         loan = described_class.create(
           carrier: carrier,

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -15,44 +15,44 @@ RSpec.describe Membership, type: :model do
     expect(expired).to be_valid
   end
 
-  describe "associations" do
-    it "requires a user" do
+  describe 'associations' do
+    it 'requires a user' do
       membership.user = nil
 
       expect(membership).not_to be_valid
     end
 
-    it "requires a membership type" do
+    it 'requires a membership type' do
       membership.membership_type = nil
 
       expect(membership).not_to be_valid
     end
   end
 
-  describe "validations" do
-    it "sets the expiration based on membership type if necessary" do
+  describe 'validations' do
+    it 'sets the expiration based on membership type if necessary' do
       membership.expiration = nil
       membership.save
 
       expect(membership.expiration).to eq(membership.effective + membership.membership_type.duration_days.days)
     end
 
-    it "requires expiration not be before effective" do
+    it 'requires expiration not be before effective' do
       membership.expiration = membership.effective - 1.day
 
       expect(membership).not_to be_valid
     end
   end
 
-  describe "#expired?" do
-    context "when expiration passed" do
-      it "returns true" do
+  describe '#expired?' do
+    context 'when expiration passed' do
+      it 'returns true' do
         expect(expired.expired?).to be true
       end
     end
 
-    context "when expiration not passed" do
-      it "returns false" do
+    context 'when expiration not passed' do
+      it 'returns false' do
         expect(membership.expired?).to be false
       end
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe Organization, type: :model do
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to have_many(:users) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
     it { is_expected.to validate_presence_of(:subdomain) }
     it { is_expected.to validate_uniqueness_of(:subdomain).case_insensitive }
   end
 
-  describe "#admin" do
-    context "with admin organization" do
-      it "goes just by subdomain for now" do
+  describe '#admin' do
+    context 'with admin organization' do
+      it 'goes just by subdomain for now' do
         expect(organizations(:admin).admin?).to be true
       end
     end
 
-    context "with non-admin organization" do
-      it "goes just by subdomain for now" do
+    context 'with non-admin organization' do
+      it 'goes just by subdomain for now' do
         expect(organizations(:midatlantic).admin?).to be false
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,55 +9,55 @@ RSpec.describe User do
   let(:expired) { users(:expired) }
   let(:admin) { users(:admin) }
 
-  describe "associations" do
+  describe 'associations' do
     it { is_expected.to belong_to(:organization) }
   end
 
-  describe "#name_with_membership type" do
-    context "with no membership" do
-      it "just returns the name" do
+  describe '#name_with_membership type' do
+    context 'with no membership' do
+      it 'just returns the name' do
         nonmember = users(:nonmember)
 
         expect(nonmember.name_with_membership).to eq(nonmember.name.full)
       end
     end
 
-    context "with current membership" do
-      it "returns the full name with the membership type short name" do
-        expect(member.name_with_membership).to eq("Member Bember - AN")
+    context 'with current membership' do
+      it 'returns the full name with the membership type short name' do
+        expect(member.name_with_membership).to eq('Member Bember - AN')
       end
     end
 
-    context "with expired membership" do
-      it "returns the full name with the membership type short name indicating expired" do
+    context 'with expired membership' do
+      it 'returns the full name with the membership type short name indicating expired' do
         expired = users(:expired)
 
-        expect(expired.name_with_membership).to eq("Expired Bember - AN (Expired)")
+        expect(expired.name_with_membership).to eq('Expired Bember - AN (Expired)')
       end
     end
   end
 
-  describe "#current_membership" do
-    context "with no membership" do
-      it "is nil" do
+  describe '#current_membership' do
+    context 'with no membership' do
+      it 'is nil' do
         expect(nonmember.current_membership).to be_nil
       end
     end
 
-    context "with an expired membership" do
-      it "is nil" do
+    context 'with an expired membership' do
+      it 'is nil' do
         expect(expired.current_membership).to be_nil
       end
     end
 
-    context "with current membership" do
-      it "returns the membership" do
+    context 'with current membership' do
+      it 'returns the membership' do
         expect(member.current_membership).to eq(memberships(:member))
       end
     end
 
-    context "with upcoming membership" do
-      it "is nil" do
+    context 'with upcoming membership' do
+      it 'is nil' do
         expect(upcoming.current_membership).to be_nil
       end
     end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -19,19 +19,19 @@ RSpec.describe ApplicationPolicy do
   let(:member) { users(:member) }
 
   permissions :create?, :destroy?, :edit?, :index?, :new?, :show?, :update? do
-    it "denies access" do
+    it 'denies access' do
       expect(policy).not_to permit(admin)
       expect(policy).not_to permit(volunteer)
       expect(policy).not_to permit(member)
     end
   end
 
-  describe "Scope" do
+  describe 'Scope' do
     let(:scope_admin) { Pundit.policy_scope!(admin, DummyPundit) }
     let(:scope_volunteer) { Pundit.policy_scope!(admin, DummyPundit) }
     let(:scope_member) { Pundit.policy_scope!(admin, DummyPundit) }
 
-    it "allows all" do
+    it 'allows all' do
       expect(scope_admin.to_a).to match_array([1, 2, 3])
       expect(scope_volunteer.to_a).to match_array([1, 2, 3])
       expect(scope_member.to_a).to match_array([1, 2, 3])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,11 +6,11 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rspec'
-require "pundit/rspec"
+require 'pundit/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "Agreements", type: :request do
+RSpec.describe 'Agreements', type: :request do
   let!(:agreement) { agreements(:agreement) }
   let(:organization) { organizations(:midatlantic) }
 
@@ -16,7 +16,7 @@ RSpec.describe "Agreements", type: :request do
     end
   end
 
-  describe "GET /agreements/new" do
+  describe 'GET /agreements/new' do
     it_behaves_like 'admin authorized-only resource', :get do
       let(:endpoint) { new_agreement_url }
     end
@@ -93,7 +93,7 @@ RSpec.describe "Agreements", type: :request do
   describe 'DELETE /location/:id' do
     let(:agreement) { Agreement.create(title: 'Test', content: 'Test', organization: organization) }
 
-    it_behaves_like "admin authorized-only resource", :delete do
+    it_behaves_like 'admin authorized-only resource', :delete do
       let(:agreement) { Agreement.create(title: 'Test', content: 'Test', organization: organization) }
       let(:endpoint) { agreement_url(agreement) }
     end

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "Application", type: :request do
+RSpec.describe 'Application', type: :request do
   describe 'no tenant redirect' do
     context 'without session' do
       it 'redirects to home index' do
@@ -23,18 +23,18 @@ RSpec.describe "Application", type: :request do
   end
 
   describe 'wrong tenant redirect' do
-    it "redirects to sign in" do
+    it 'redirects to sign in' do
       sign_in users(:member)
-      get users_url(subdomain: "admin")
+      get users_url(subdomain: 'admin')
 
       expect(response).to redirect_to(new_user_session_url)
     end
   end
 
-  describe "admin organization redirect" do
-    context "with no session" do
-      it "redirects to sign in" do
-        get root_url(domain: "stage.example.com", subdomain: "admin")
+  describe 'admin organization redirect' do
+    context 'with no session' do
+      it 'redirects to sign in' do
+        get root_url(domain: 'stage.example.com', subdomain: 'admin')
 
         expect(response).to redirect_to(new_user_session_url)
       end

--- a/spec/requests/carriers/loans_spec.rb
+++ b/spec/requests/carriers/loans_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "Loans", type: :request do
+RSpec.describe 'Loans', type: :request do
   let(:volunteer) { users(:volunteer) }
   let(:member) { users(:member) }
   let(:carrier) { carriers(:carrier) }

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe "Categories", type: :request do
+RSpec.describe 'Categories', type: :request do
   let!(:category) { categories(:category_parent) }
 
   describe 'GET /categories' do
     it 'has http status 200' do
       sign_in users(:admin_org)
-      get categories_url(subdomain: "admin")
+      get categories_url(subdomain: 'admin')
 
       expect(response).to be_successful
       expect(response.body).to match(/category parent/)
@@ -22,9 +22,9 @@ RSpec.describe "Categories", type: :request do
     context 'with valid attributes' do
       it 'creates a category' do
         sign_in users(:admin_org)
-        post categories_url(subdomain: "admin"), params: { category: valid_attr }
+        post categories_url(subdomain: 'admin'), params: { category: valid_attr }
 
-        expect(response).to redirect_to(category_url(assigns(:category), subdomain: "admin"))
+        expect(response).to redirect_to(category_url(assigns(:category), subdomain: 'admin'))
         expect(flash[:notice]).to eq('Category was successfully created.')
       end
     end
@@ -32,7 +32,7 @@ RSpec.describe "Categories", type: :request do
     context 'with invalid attributes' do
       it "doesn't create a category" do
         sign_in users(:admin_org)
-        send :post, categories_url(subdomain: "admin"), params: { category: invalid_attr }
+        send :post, categories_url(subdomain: 'admin'), params: { category: invalid_attr }
 
         expect(response.body).to match(/prohibited this/)
       end
@@ -42,7 +42,7 @@ RSpec.describe "Categories", type: :request do
   describe 'GET /categories/:id' do
     it 'has have_http_status 200' do
       sign_in users(:admin_org)
-      get categories_url(category, subdomain: "admin")
+      get categories_url(category, subdomain: 'admin')
 
       expect(response).to be_successful
       expect(response.body).to match(/category parent/)
@@ -56,7 +56,7 @@ RSpec.describe "Categories", type: :request do
     context 'with valid attributes' do
       it 'updates the category' do
         sign_in users(:admin_org)
-        put category_url(category, subdomain: "admin"), params: { category: valid_attr }
+        put category_url(category, subdomain: 'admin'), params: { category: valid_attr }
 
         expect(flash[:notice]).to eq('Category was successfully updated.')
       end
@@ -65,7 +65,7 @@ RSpec.describe "Categories", type: :request do
     context 'with invalid attributes' do
       it "doesn't update the category" do
         sign_in users(:admin_org)
-        put category_url(category, subdomain: "admin"), params: { category: invalid_attr }
+        put category_url(category, subdomain: 'admin'), params: { category: invalid_attr }
 
         expect(response.body).to match(/prohibited this/)
       end
@@ -77,7 +77,7 @@ RSpec.describe "Categories", type: :request do
 
     it 'destroys the category' do
       sign_in users(:admin_org)
-      delete category_url(category, subdomain: "admin")
+      delete category_url(category, subdomain: 'admin')
 
       expect(response).to have_http_status(:found)
       expect(flash[:alert]).to eq('Category was successfully destroyed.')
@@ -88,7 +88,7 @@ RSpec.describe "Categories", type: :request do
     it 'has a routing error' do
       sign_in users(:member)
       expect do
-        get "http://midatlantic.example.com/categories"
+        get 'http://midatlantic.example.com/categories'
       end.to raise_error(ActionController::RoutingError)
     end
   end

--- a/spec/requests/fee_types_spec.rb
+++ b/spec/requests/fee_types_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "FeeTypes", type: :request do
+RSpec.describe 'FeeTypes', type: :request do
   let!(:fee_type) { fee_types(:upgrade) }
   let(:organization) { organizations(:midatlantic) }
 
@@ -16,7 +16,7 @@ RSpec.describe "FeeTypes", type: :request do
     end
   end
 
-  describe "GET /fee_types/new" do
+  describe 'GET /fee_types/new' do
     it_behaves_like 'admin authorized-only resource', :get do
       let(:endpoint) { new_fee_type_url }
     end
@@ -97,7 +97,7 @@ RSpec.describe "FeeTypes", type: :request do
   describe 'DELETE /fee_type/:id' do
     let(:fee_type) { FeeType.create(name: 'Test', fee_cents: 10, organization: organization) }
 
-    it_behaves_like "admin authorized-only resource", :delete do
+    it_behaves_like 'admin authorized-only resource', :delete do
       let(:fee_type) { FeeType.create(name: 'Test', fee_cents: 10, organization: organization) }
       let(:endpoint) { fee_type_url(fee_type) }
     end

--- a/spec/requests/loan_listing_spec.rb
+++ b/spec/requests/loan_listing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "LoanListing", type: :request do
+RSpec.describe 'LoanListing', type: :request do
   describe '#index' do
     let(:admin) { users(:admin) }
 

--- a/spec/requests/locations_spec.rb
+++ b/spec/requests/locations_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "Locations", type: :request do
+RSpec.describe 'Locations', type: :request do
   let!(:location) { locations(:lancaster) }
   let(:organization) { organizations(:midatlantic) }
 
@@ -16,7 +16,7 @@ RSpec.describe "Locations", type: :request do
     end
   end
 
-  describe "GET /locations/new" do
+  describe 'GET /locations/new' do
     it_behaves_like 'admin authorized-only resource', :get do
       let(:endpoint) { new_location_url }
     end
@@ -42,7 +42,7 @@ RSpec.describe "Locations", type: :request do
     end
 
     context 'with invalid attributes' do
-      it "does not create a location" do
+      it 'does not create a location' do
         sign_in users(:admin)
         send :post, locations_url, params: { location: invalid_attr }
 
@@ -107,7 +107,7 @@ RSpec.describe "Locations", type: :request do
   describe 'DELETE /location/:id' do
     let(:location) { organization.locations.create(name: 'Test') }
 
-    it_behaves_like "admin authorized-only resource", :delete do
+    it_behaves_like 'admin authorized-only resource', :delete do
       let(:location) { organization.locations.create(name: 'Test') }
       let(:endpoint) { location_url(location) }
     end

--- a/spec/requests/membership_types_spec.rb
+++ b/spec/requests/membership_types_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "MembershipTypes", type: :request do
+RSpec.describe 'MembershipTypes', type: :request do
   let!(:membership_type) { membership_types(:annual) }
   let(:organization) { organizations(:midatlantic) }
 
@@ -16,7 +16,7 @@ RSpec.describe "MembershipTypes", type: :request do
     end
   end
 
-  describe "GET /membership_types/new" do
+  describe 'GET /membership_types/new' do
     it_behaves_like 'admin authorized-only resource', :get do
       let(:endpoint) { new_membership_type_url }
     end
@@ -32,7 +32,7 @@ RSpec.describe "MembershipTypes", type: :request do
           fee_cents: 30_00,
           duration_days: 3,
           number_of_items: 3,
-          description: "A text description goes here."
+          description: 'A text description goes here.'
         } }
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe "MembershipTypes", type: :request do
         fee_cents: 30_00,
         duration_days: 3,
         number_of_items: 3,
-        description: "A text description goes here."
+        description: 'A text description goes here.'
       }
     end
     let(:invalid_attr) { { name: '' } }
@@ -90,7 +90,7 @@ RSpec.describe "MembershipTypes", type: :request do
           fee_cents: 30_00,
           duration_days: 3,
           number_of_items: 3,
-          description: "A text description goes here."
+          description: 'A text description goes here.'
         } }
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe "MembershipTypes", type: :request do
         fee_cents: 30_00,
         duration_days: 3,
         number_of_items: 3,
-        description: "A text description goes here."
+        description: 'A text description goes here.'
       }
     end
     let(:invalid_attr) { { name: '' } }
@@ -135,11 +135,11 @@ RSpec.describe "MembershipTypes", type: :request do
         fee_cents: 30_00,
         duration_days: 3,
         number_of_items: 3,
-        description: "A text description goes here."
+        description: 'A text description goes here.'
       )
     end
 
-    it_behaves_like "admin authorized-only resource", :delete do
+    it_behaves_like 'admin authorized-only resource', :delete do
       let(:membership_type) do
         MembershipType.create(
           organization: organization,
@@ -148,7 +148,7 @@ RSpec.describe "MembershipTypes", type: :request do
           fee_cents: 30_00,
           duration_days: 3,
           number_of_items: 3,
-          description: "A text description goes here."
+          description: 'A text description goes here.'
         )
       end
       let(:endpoint) { membership_type_url(membership_type) }

--- a/spec/requests/users/memberships_spec.rb
+++ b/spec/requests/users/memberships_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "Users::Memberships", type: :request do
+RSpec.describe 'Users::Memberships', type: :request do
   let(:volunteer) { users(:volunteer) }
   let(:nonmember) { users(:nonmember) }
   let(:member) { users(:member) }
@@ -34,7 +34,7 @@ RSpec.describe "Users::Memberships", type: :request do
       it 'creates the membership' do
         sign_in volunteer
 
-        expect { post user_memberships_url(nonmember), params: { membership: valid_params.merge(effective: "") } }
+        expect { post user_memberships_url(nonmember), params: { membership: valid_params.merge(effective: '') } }
           .not_to change(Membership, :count)
         expect(response.body).to match(/form data-modal=\"true\"/)
         expect(response.body).to match(/Create Membership/)

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "Users", type: :request do
+RSpec.describe 'Users', type: :request do
   let(:admin)  { users(:admin) }
   let(:member) { users(:member) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -76,7 +76,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+    config.default_formatter = 'doc'
   end
 
   # Print the 10 slowest examples and example groups at the

--- a/spec/support/feature_subdomain_helpers.rb
+++ b/spec/support/feature_subdomain_helpers.rb
@@ -2,10 +2,10 @@
 
 module FeatureSubdomainHelpers
   # Sets Capybara to use a given subdomain.
-  def within_subdomain(subdomain = "admin")
+  def within_subdomain(subdomain = 'admin')
     before { Capybara.default_host = "http://#{subdomain}.example.com" }
 
-    after  { Capybara.default_host = "http://www.example.com" }
+    after  { Capybara.default_host = 'http://www.example.com' }
 
     yield
   end

--- a/spec/support/features/devise_helpers.rb
+++ b/spec/support/features/devise_helpers.rb
@@ -5,19 +5,19 @@ module Features
     visit new_user_session_url
     fill_in 'user_email', with: email
     fill_in 'user_password', with: password
-    click_button "Log In"
+    click_button 'Log In'
   end
 
   def user_sign_out
-    click_link "Logout"
+    click_link 'Logout'
   end
 
   def user_should_be_signed_in
     visit root_url
-    expect(page).to have_content "Logout"
+    expect(page).to have_content 'Logout'
   end
 
   def user_should_be_signed_out
-    expect(page).to have_content "Log In"
+    expect(page).to have_content 'Log In'
   end
 end

--- a/spec/support/request_subdomain_helpers.rb
+++ b/spec/support/request_subdomain_helpers.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module RequestSubdomainHelpers
-  def within_subdomain(subdomain = "admin")
+  def within_subdomain(subdomain = 'admin')
     before { host! "#{subdomain}.example.com" }
 
-    after  { host! "www.example.com" }
+    after  { host! 'www.example.com' }
 
     yield
   end

--- a/spec/validators/subdomain_validator_spec.rb
+++ b/spec/validators/subdomain_validator_spec.rb
@@ -11,42 +11,42 @@ class Subdomain
 end
 
 RSpec.describe SubdomainValidator, type: :validator do
-  it "validates if the value is not present" do
+  it 'validates if the value is not present' do
     subdomain = Subdomain.new(subdomain: nil)
     expect(subdomain).to be_valid
   end
 
-  it "does not validate subdomains with reserved names" do
+  it 'does not validate subdomains with reserved names' do
     %w[www ftp mail pop smtp ssl sftp].each do |reserved_name|
       subdomain = Subdomain.new(subdomain: reserved_name)
       expect(subdomain).not_to be_valid
     end
   end
 
-  it "does not validate subdomains when the length is not between 3 and 63 letters" do
-    short_subdomain = Subdomain.new(subdomain: "ww")
+  it 'does not validate subdomains when the length is not between 3 and 63 letters' do
+    short_subdomain = Subdomain.new(subdomain: 'ww')
     expect(short_subdomain).not_to be_valid
 
-    long_subdomain = Subdomain.new(subdomain: "a" * 64)
+    long_subdomain = Subdomain.new(subdomain: 'a' * 64)
     expect(long_subdomain).not_to be_valid
 
-    valid_length_subdomain = Subdomain.new(subdomain: "a" * 55)
+    valid_length_subdomain = Subdomain.new(subdomain: 'a' * 55)
     expect(valid_length_subdomain).to be_valid
   end
 
-  it "does not validate subdomains when they start or end with a hyphen" do
-    hyphen_prefixed_subdomain = Subdomain.new(subdomain: "-hello")
+  it 'does not validate subdomains when they start or end with a hyphen' do
+    hyphen_prefixed_subdomain = Subdomain.new(subdomain: '-hello')
     expect(hyphen_prefixed_subdomain).not_to be_valid
 
-    hyphen_suffixed_subdomain = Subdomain.new(subdomain: "bye-")
+    hyphen_suffixed_subdomain = Subdomain.new(subdomain: 'bye-')
     expect(hyphen_suffixed_subdomain).not_to be_valid
 
-    hyphened_subdomain = Subdomain.new(subdomain: "hello-world")
+    hyphened_subdomain = Subdomain.new(subdomain: 'hello-world')
     expect(hyphened_subdomain).to be_valid
   end
 
-  it "does not validate if the subdomain is not alphanumeric" do
-    non_alphanumeric_subdomain = Subdomain.new(subdomain: "_!3482asdkjas")
+  it 'does not validate if the subdomain is not alphanumeric' do
+    non_alphanumeric_subdomain = Subdomain.new(subdomain: '_!3482asdkjas')
     expect(non_alphanumeric_subdomain).not_to be_valid
   end
 end


### PR DESCRIPTION
There are several 'to be removed' rules in the .rubocop.yml
configuration. This branch resolves the issues and removes the rules.

- Prefer single line conditionals when possible
- Prefer guard clauses over if/else when possible
- Prefer single-quotes when interpolation is not required
  (auto-corrected)

<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves: Didn't actually create an issue for this...

### Description

Resolves the three 'to be removed' rules in the Rubocop config

### Type of change

<!-- Please delete options that are not relevant. -->

* Technical Debt

### How Has This Been Tested?

Simple refactor. No new tests needed. All old tests pass.