### PR TITLE
Restyle quick link menu

### DIFF
--- a/app/views/layouts/_header_signed_in.html.erb
+++ b/app/views/layouts/_header_signed_in.html.erb
@@ -38,15 +38,15 @@
         </li>
       </ul>
       <ul class="nav navbar-nav navbar-middle">
-        <li class="dropdown">
+        <div class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Quick Access<span class="caret"></span></a>
-          <ul class="dropdown-menu" role="menu">
-            <li><%= link_to 'Locations', locations_path %></li>
-            <li><%= link_to 'Agreements', agreements_path %></li>
-            <li><%= link_to 'Fee Types', fee_types_path %></li>
-            <li><%= link_to 'Membership Types', membership_types_path %></li>
-          </ul>
-        </li>
+          <div class="dropdown-menu" role="menu">
+            <%= link_to 'Locations', locations_path, class: 'dropdown-item' %>
+            <%= link_to 'Agreements', agreements_path, class: 'dropdown-item' %>
+            <%= link_to 'Fee Types', fee_types_path, class: 'dropdown-item' %>
+            <%= link_to 'Membership Types', membership_types_path, class: 'dropdown-item' %></li>
+          </vdiv>
+        </div>
       </ul>
     <% end %>
     <ul class="navbar-nav ml-auto">


### PR DESCRIPTION

Resolves #319

### Description

Change the quick link menu mark up to be more in line with Bootstrap
styles.

### Type of change

<!-- Please delete options that are not relevant. -->

* Style (Bug) fix (non-breaking change which fixes an issue)

### Screenshots

<img width="550" alt="Screen Shot 2020-05-19 at 11 33 59 PM" src="https://user-images.githubusercontent.com/1638226/83475949-703a3c80-a45d-11ea-84d1-e38a80bdf0f0.png">
