### PR TITLE
Add paranoid to avoid show emails

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -81,7 +81,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.


### PR DESCRIPTION
Resolves #373

### Description
Guide questions:
  - Device has paranoid to avoid this emails problems.
  
### How Has This Been Tested?
It's not necessary. 

### Screenshots
![Captura de Tela 2020-08-03 às 14 59 46](https://user-images.githubusercontent.com/505372/89215298-c8e19f00-d59e-11ea-852a-f158ee13162b.png)
